### PR TITLE
Fix projections for color images

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -249,7 +249,8 @@ class forcedialog(QDialog):
                 pidlabel.setText(pre + ll[1] + post)
                 self.gridLayout.addWidget(pidlabel, i, 1, 1, 1)
 
-                lines = open(dir + file).readlines()
+                with open(dir + file) as f:
+                    lines = f.readlines()
                 ttylabel = QLabel(self)
                 ttylabel.setTextFormat(QtCore.Qt.RichText)
                 ttylabel.setText(pre + lines[0].strip() + post)

--- a/pycaqtimage/pycaqtimage.sip
+++ b/pycaqtimage/pycaqtimage.sip
@@ -546,7 +546,7 @@ static void _computeRoiProj(ImageBuffer* imageBuffer, QRectF* rectRoi, bool bPro
 	uint32_t* pPixel = pPixelLineStart;
 	for (int iX = x1; iX <= x2; ++iX, ++pPixel) {
 #define SUMRGB(x) (((x)&0xff)+(((x)>>8)&0xff)+(((x)>>16)&0xff))
-	    int iValue = isColor ? SUMRGB(*pPixel) : *pPixel;
+	    uint32_t iValue = isColor ? SUMRGB(*pPixel) : *pPixel;
 	    if ( iValue >= 0x10000) {
 		fprintf(stderr, "Pixel value (%d,%d) too large: value 0x%x\n", iX, iY, iValue);
 		continue;

--- a/pycaqtimage/pycaqtimage.sip
+++ b/pycaqtimage/pycaqtimage.sip
@@ -540,11 +540,13 @@ static void _computeRoiProj(ImageBuffer* imageBuffer, QRectF* rectRoi, bool bPro
     uint64_t  u64PixelSum           = 0;
     uint64_t  u64PixelSqSum         = 0;
     uint32_t* pPixelLineStart       = pImgValue + y1 * width + x1;
+    int isColor = imageBuffer->isColor && !imageBuffer->useGray;
 
     for (int iY = y1; iY <= y2; ++iY, pPixelLineStart += width) {
 	uint32_t* pPixel = pPixelLineStart;
 	for (int iX = x1; iX <= x2; ++iX, ++pPixel) {
-	    int iValue = *pPixel;
+#define SUMRGB(x) (((x)&0xff)+(((x)>>8)&0xff)+(((x)>>16)&0xff))
+	    int iValue = isColor ? SUMRGB(*pPixel) : *pPixel;
 	    if ( iValue >= 0x10000) {
 		fprintf(stderr, "Pixel value (%d,%d) too large: value 0x%x\n", iX, iY, iValue);
 		continue;


### PR DESCRIPTION
If the image is color, we still want to work on the grayscale image for projections, otherwise we get into math error problems.

Also, close a file, as Zach pointed out.
