### PR TITLE
FIX: dialog now reflects the fact that the camera has been disconnected

### DIFF
--- a/dialogs.py
+++ b/dialogs.py
@@ -106,26 +106,22 @@ class timeoutdialog(QDialog):
 
     def setText(self, line1, line2):
         # Ugly, ugly, ugly... cut and paste from timeout_ui.py.
-        self.ui.label.setText(
-            QApplication.translate(
-                "Dialog",
-                '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">\n'
-                '<html><head><meta name="qrichtext" content="1" /><style type="text/css">\n'
-                "p, li { white-space: pre-wrap; }\n"
-                "</style></head><body style=\" font-family:'Sans Serif'; font-size:9pt; font-weight:400; font-style:normal;\">\n"
-                '<table style="-qt-table-type: root; margin-top:4px; margin-bottom:4px; margin-left:4px; margin-right:4px;">\n'
-                "<tr>\n"
-                '<td style="border: none;">\n'
-                '<p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-size:20pt; font-weight:600;">'
-                + line1
-                + "</span></p>\n"
-                '<p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-size:20pt; font-weight:600;">'
-                + line2
-                + "</span></p></td></tr></table></body></html>",
-                None,
-                QApplication.UnicodeUTF8,
-            )
-        )
+        _translate = QtCore.QCoreApplication.translate
+        self.ui.label.setText(_translate(
+            "Dialog", 
+            "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/REC-html40/strict.dtd\">\n"
+            "<html><head><meta name=\"qrichtext\" content=\"1\" /><style type=\"text/css\">\n"
+"p, li { white-space: pre-wrap; }\n"
+            "</style></head><body style=\" font-family:\'Sans Serif\'; font-size:9pt; font-weight:400; font-style:normal;\">\n"
+            "<table border=\"0\" style=\"-qt-table-type: root; margin-top:4px; margin-bottom:4px; margin-left:4px; margin-right:4px;\">\n"
+            "<tr>\n"
+            "<td style=\"border: none;\">\n"
+            "<p style=\" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"><span style=\" font-size:20pt; font-weight:600;\">"
+            + line1
+            + "</span></p>\n"
+            "<p style=\" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"><span style=\" font-size:20pt; font-weight:600;\">"
+            + line2
+            + "</span></p></td></tr></table></body></html>"))
 
     # Called when our initial countdown timer has expired.
     # Show the dialog and


### PR DESCRIPTION
After the timeout, the dialog should change to reflect the fact that the camera has been disconnected.  I did this by copying code from the generated timeout_ui.py and editing it slightly.

Now things have changed since the upgrade to PyQt5, so the old copied call no longer works.

So I copied the new call and edited it slightly.

This fixes https://jira.slac.stanford.edu/browse/ECS-1801.
