### PR TITLE
Adding Display Format feature

### DIFF
--- a/ProjWidget.py
+++ b/ProjWidget.py
@@ -270,11 +270,11 @@ class ProjWidget(QWidget):
         fwhm = self.gui.calib * out.params["fwhm"].value
         e2w = self.gui.calib * out.params["e2w"].value
         if self.is_x:
-            self.gui.ui.lineEditFWHMx.setText("%12.8g" % (fwhm))
-            self.gui.ui.lineEdite2x.setText("%12.8g" % (e2w))
+            self.gui.ui.lineEditFWHMx.setText(self.gui.displayFormat % (fwhm))
+            self.gui.ui.lineEdite2x.setText(self.gui.displayFormat % (e2w))
         else:
-            self.gui.ui.lineEditFWHMy.setText("%12.8g" % (fwhm))
-            self.gui.ui.lineEdite2y.setText("%12.8g" % (e2w))
+            self.gui.ui.lineEditFWHMy.setText(self.gui.displayFormat % (fwhm))
+            self.gui.ui.lineEdite2y.setText(self.gui.displayFormat % (e2w))
         return (ymin, ymax)
 
     def plotLineout(

--- a/advanced.ui
+++ b/advanced.ui
@@ -93,7 +93,7 @@
    <item row="4" column="0">
     <widget class="QLabel" name="label_5">
      <property name="text">
-      <string>Display Format</string>
+      <string>FWHM Display Format</string>
      </property>
     </widget>
    </item>

--- a/advanced.ui
+++ b/advanced.ui
@@ -7,54 +7,17 @@
     <x>0</x>
     <y>0</y>
     <width>380</width>
-    <height>171</height>
+    <height>220</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Dialog</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0" colspan="2">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Viewing Area Width (&gt; 450 pixels)</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0">
-    <widget class="QPushButton" name="showevr">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>33</height>
-      </size>
-     </property>
-     <property name="text">
-      <string>Open Evr</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0" colspan="2">
-    <widget class="QLabel" name="label_3">
-     <property name="text">
-      <string>Viewing Area Height (&gt; 450 pixels)</string>
-     </property>
-    </widget>
-   </item>
    <item row="1" column="2">
     <widget class="QLineEdit" name="viewHeight"/>
    </item>
-   <item row="4" column="0" colspan="3">
-    <widget class="QCheckBox" name="configCheckBox">
-     <property name="text">
-      <string>Display Camera Configuration on Main Screen</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="2">
-    <widget class="QLineEdit" name="viewWidth"/>
-   </item>
-   <item row="5" column="1" colspan="2">
+   <item row="6" column="1" colspan="2">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -67,6 +30,27 @@
      </property>
     </widget>
    </item>
+   <item row="1" column="0" colspan="2">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>Viewing Area Height (&gt; 450 pixels)</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0" colspan="2">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Viewing Area Width (&gt; 450 pixels)</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0" colspan="2">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>Spatial Calibration PV name</string>
+     </property>
+    </widget>
+   </item>
    <item row="2" column="0" colspan="2">
     <widget class="QLabel" name="label_2">
      <property name="text">
@@ -74,16 +58,42 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="2">
-    <widget class="QLineEdit" name="projSize"/>
+   <item row="5" column="0" colspan="3">
+    <widget class="QCheckBox" name="configCheckBox">
+     <property name="text">
+      <string>Display Camera Configuration on Main Screen</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <widget class="QPushButton" name="showevr">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>33</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>Open Evr</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="2">
+    <widget class="QLineEdit" name="viewWidth"/>
    </item>
    <item row="3" column="2">
     <widget class="QLineEdit" name="calibPVName"/>
    </item>
-   <item row="3" column="0" colspan="2">
-    <widget class="QLabel" name="label_4">
+   <item row="2" column="2">
+    <widget class="QLineEdit" name="projSize"/>
+   </item>
+   <item row="4" column="2">
+    <widget class="QLineEdit" name="displayFormat"/>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_5">
      <property name="text">
-      <string>Spatial Calibration PV name</string>
+      <string>Display Format</string>
      </property>
     </widget>
    </item>

--- a/camviewer_ui_impl.py
+++ b/camviewer_ui_impl.py
@@ -2266,7 +2266,6 @@ class GraphicUserInterface(QMainWindow):
                 self.advdialog.ui.viewWidth.setText(str(self.viewwidth))
                 self.advdialog.ui.viewHeight.setText(str(self.viewheight))
                 self.advdialog.ui.projSize.setText(str(self.projsize))
-                # self.advdialog
             except Exception:
                 print("onAdvanced resizing threw an exception")
             self.setCalibPV(self.advdialog.ui.calibPVName.text())
@@ -2277,7 +2276,7 @@ class GraphicUserInterface(QMainWindow):
 
     def validDisplayFormat(self, rawString):
         return re.match("^%\d+(\.\d*)?[efg]$", rawString) is not None
-        
+
     def calibPVmon(self, exception=None):
         if exception is None:
             self.calib = self.calibPV.value

--- a/camviewer_ui_impl.py
+++ b/camviewer_ui_impl.py
@@ -2061,10 +2061,14 @@ class GraphicUserInterface(QMainWindow):
                     self.ui.horizontalSliderLens.setMaximum(100)
                 if len(lensName) > 1:
                     self.putlensPv = Pv(lensName[0], initialize=True)
-                    self.lensPv = Pv(lensName[1], initialize=True, monitor=self.lensPvUpdateCallback)
+                    self.lensPv = Pv(
+                        lensName[1], initialize=True, monitor=self.lensPvUpdateCallback
+                    )
                 else:
                     self.putlensPv = None
-                    self.lensPv = Pv(lensName[0], initialize=True, monitor=self.lensPvUpdateCallback)
+                    self.lensPv = Pv(
+                        lensName[0], initialize=True, monitor=self.lensPvUpdateCallback
+                    )
                 self.lensPv.wait_ready(1.0)
                 if self.putlensPv is not None:
                     self.putlensPv.wait_ready(1.0)
@@ -2855,13 +2859,14 @@ class GraphicUserInterface(QMainWindow):
         except Exception:
             pass
         try:
-            if self.cfg.projdisplayFormat[0] == '"' and self.cfg.projdisplayFormat[-1] == '"':
+            if (
+                self.cfg.projdisplayFormat[0] == '"'
+                and self.cfg.projdisplayFormat[-1] == '"'
+            ):
                 self.displayFormat = self.cfg.projdisplayFormat[1:-1]
             else:
                 self.displayFormat = "%12.8g"
         except Exception:
             self.displayFormat = "%12.8g"
-        
-
 
         self.cfg = None

--- a/camviewer_ui_impl.py
+++ b/camviewer_ui_impl.py
@@ -2596,13 +2596,11 @@ class GraphicUserInterface(QMainWindow):
         self.cfg.add("projection", "0")
         self.cfg.add("markers", "0")
         self.cfg.add("dispspec", "0")
-        # self.cfg.add("displayFormat", "%12.8g")
         if not self.cfg.read(self.cfgdir + "GLOBAL"):
             self.cfg.add("config", "1")
             self.cfg.add("projection", "1")
             self.cfg.add("markers", "1")
             self.cfg.add("dispspec", "0")
-            # self.cfg.add("displayFormat","%12.8g")
         if self.options is not None:
             # Let the command line options override the config file!
             if self.options.config is not None:
@@ -2613,8 +2611,6 @@ class GraphicUserInterface(QMainWindow):
                 self.cfg.add("markers", self.options.marker)
             if self.options.camcfg is not None:
                 self.cfg.add("dispspec", self.options.camcfg)
-            # if self.options.displayFormat is not None:
-            #     self.cfg.add("displayFormat", self.options.displayFormat)
 
         # Read the config file
         #

--- a/dialogs.py
+++ b/dialogs.py
@@ -107,21 +107,24 @@ class timeoutdialog(QDialog):
     def setText(self, line1, line2):
         # Ugly, ugly, ugly... cut and paste from timeout_ui.py.
         _translate = QtCore.QCoreApplication.translate
-        self.ui.label.setText(_translate(
-            "Dialog", 
-            "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.0//EN\" \"http://www.w3.org/TR/REC-html40/strict.dtd\">\n"
-            "<html><head><meta name=\"qrichtext\" content=\"1\" /><style type=\"text/css\">\n"
-"p, li { white-space: pre-wrap; }\n"
-            "</style></head><body style=\" font-family:\'Sans Serif\'; font-size:9pt; font-weight:400; font-style:normal;\">\n"
-            "<table border=\"0\" style=\"-qt-table-type: root; margin-top:4px; margin-bottom:4px; margin-left:4px; margin-right:4px;\">\n"
-            "<tr>\n"
-            "<td style=\"border: none;\">\n"
-            "<p style=\" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"><span style=\" font-size:20pt; font-weight:600;\">"
-            + line1
-            + "</span></p>\n"
-            "<p style=\" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;\"><span style=\" font-size:20pt; font-weight:600;\">"
-            + line2
-            + "</span></p></td></tr></table></body></html>"))
+        self.ui.label.setText(
+            _translate(
+                "Dialog",
+                '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0//EN" "http://www.w3.org/TR/REC-html40/strict.dtd">\n'
+                '<html><head><meta name="qrichtext" content="1" /><style type="text/css">\n'
+                "p, li { white-space: pre-wrap; }\n"
+                "</style></head><body style=\" font-family:'Sans Serif'; font-size:9pt; font-weight:400; font-style:normal;\">\n"
+                '<table border="0" style="-qt-table-type: root; margin-top:4px; margin-bottom:4px; margin-left:4px; margin-right:4px;">\n'
+                "<tr>\n"
+                '<td style="border: none;">\n'
+                '<p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-size:20pt; font-weight:600;">'
+                + line1
+                + "</span></p>\n"
+                '<p style=" margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;"><span style=" font-size:20pt; font-weight:600;">'
+                + line2
+                + "</span></p></td></tr></table></body></html>",
+            )
+        )
 
     # Called when our initial countdown timer has expired.
     # Show the dialog and


### PR DESCRIPTION
Adding a feature to allow the user to adjust the display format of Fid Widths FWHMH field.

This was tested by inputting several different combinations of test strings to ensure that the values were displayed correctly and checking the yagviewer/PVNAME file to make sure the setting was properly updating.