### PR TITLE
FIX: atomic writes for config/cache files

### DIFF
--- a/camviewer_ui_impl.py
+++ b/camviewer_ui_impl.py
@@ -2711,16 +2711,16 @@ class GraphicUserInterface(QMainWindow):
         self.cfg = None
 
 
-def write_camera_config(self: GraphicUserInterface) -> None:
-    f = open(self.cfgdir + self.cameraBase, "w")
-    f.write("projsize    " + str(self.projsize) + "\n")
-    f.write("viewwidth   " + str(self.viewwidth) + "\n")
-    f.write("viewheight  " + str(self.viewheight) + "\n")
+def write_camera_config(gui: GraphicUserInterface) -> None:
+    f = open(gui.cfgdir + gui.cameraBase, "w")
+    f.write("projsize    " + str(gui.projsize) + "\n")
+    f.write("viewwidth   " + str(gui.viewwidth) + "\n")
+    f.write("viewheight  " + str(gui.viewheight) + "\n")
     f.write("portrait    " + str(int(param.orientation == param.ORIENT90)) + "\n")
     f.write("orientation " + str(param.orientation) + "\n")
-    f.write("autorange   " + str(int(self.ui.checkBoxProjAutoRange.isChecked())) + "\n")
+    f.write("autorange   " + str(int(gui.ui.checkBoxProjAutoRange.isChecked())) + "\n")
     f.write("use_abs     1\n")
-    rz = self.ui.display_image.rectZoom.abs()
+    rz = gui.ui.display_image.rectZoom.abs()
     f.write(
         "rectzoom    "
         + str(rz.x())
@@ -2732,54 +2732,54 @@ def write_camera_config(self: GraphicUserInterface) -> None:
         + str(rz.height())
         + "\n"
     )
-    f.write("colormap    " + str(self.ui.comboBoxColor.currentText()) + "\n")
-    f.write("colorscale  " + str(self.ui.comboBoxScale.currentText()) + "\n")
-    f.write("colormin    " + self.ui.lineEditRangeMin.text() + "\n")
-    f.write("colormax    " + self.ui.lineEditRangeMax.text() + "\n")
-    f.write("grayscale   " + str(int(self.ui.grayScale.isChecked())) + "\n")
-    roi = self.ui.display_image.rectRoi.abs()
+    f.write("colormap    " + str(gui.ui.comboBoxColor.currentText()) + "\n")
+    f.write("colorscale  " + str(gui.ui.comboBoxScale.currentText()) + "\n")
+    f.write("colormin    " + gui.ui.lineEditRangeMin.text() + "\n")
+    f.write("colormax    " + gui.ui.lineEditRangeMax.text() + "\n")
+    f.write("grayscale   " + str(int(gui.ui.grayScale.isChecked())) + "\n")
+    roi = gui.ui.display_image.rectRoi.abs()
     f.write("ROI         %d %d %d %d\n" % (roi.x(), roi.y(), roi.width(), roi.height()))
-    f.write("globmarks   " + str(int(self.useglobmarks)) + "\n")
-    f.write("globmarks2  " + str(int(self.useglobmarks2)) + "\n")
-    lMarker = self.ui.display_image.lMarker
+    f.write("globmarks   " + str(int(gui.useglobmarks)) + "\n")
+    f.write("globmarks2  " + str(int(gui.useglobmarks2)) + "\n")
+    lMarker = gui.ui.display_image.lMarker
     for i in range(4):
         f.write(
             "m%d          %d %d\n" % (i + 1, lMarker[i].abs().x(), lMarker[i].abs().y())
         )
-    f.write("projroi     " + str(int(self.ui.checkBoxProjRoi.isChecked())) + "\n")
+    f.write("projroi     " + str(int(gui.ui.checkBoxProjRoi.isChecked())) + "\n")
     f.write(
         "projlineout "
-        + str(int(self.ui.checkBoxM1Lineout.isChecked()))
+        + str(int(gui.ui.checkBoxM1Lineout.isChecked()))
         + " "
-        + str(int(self.ui.checkBoxM2Lineout.isChecked()))
+        + str(int(gui.ui.checkBoxM2Lineout.isChecked()))
         + " "
-        + str(int(self.ui.checkBoxM3Lineout.isChecked()))
+        + str(int(gui.ui.checkBoxM3Lineout.isChecked()))
         + " "
-        + str(int(self.ui.checkBoxM4Lineout.isChecked()))
+        + str(int(gui.ui.checkBoxM4Lineout.isChecked()))
         + "\n"
     )
-    f.write("projfit     " + str(int(self.ui.checkBoxFits.isChecked())) + "\n")
+    f.write("projfit     " + str(int(gui.ui.checkBoxFits.isChecked())) + "\n")
     f.write(
         "projfittype "
-        + str(int(self.ui.radioGaussian.isChecked()))
+        + str(int(gui.ui.radioGaussian.isChecked()))
         + " "
-        + str(int(self.ui.radioSG4.isChecked()))
+        + str(int(gui.ui.radioSG4.isChecked()))
         + " "
-        + str(int(self.ui.radioSG6.isChecked()))
+        + str(int(gui.ui.radioSG6.isChecked()))
         + "\n"
     )
-    f.write("projconstant " + str(int(self.ui.checkBoxConstant.isChecked())) + "\n")
-    f.write("projcalib   %g\n" % self.calib)
-    f.write('projcalibPV "%s"\n' % self.calibPVName)
-    f.write('projdisplayFormat "%s"\n' % self.displayFormat)
+    f.write("projconstant " + str(int(gui.ui.checkBoxConstant.isChecked())) + "\n")
+    f.write("projcalib   %g\n" % gui.calib)
+    f.write('projcalibPV "%s"\n' % gui.calibPVName)
+    f.write('projdisplayFormat "%s"\n' % gui.displayFormat)
 
     f.close()
 
 
-def write_global_config(self: GraphicUserInterface) -> None:
-    g = open(self.cfgdir + "GLOBAL", "w")
-    g.write("config      " + str(int(self.ui.showconf.isChecked())) + "\n")
-    g.write("projection  " + str(int(self.ui.showproj.isChecked())) + "\n")
-    g.write("markers     " + str(int(self.ui.showmarker.isChecked())) + "\n")
-    g.write("dispspec    " + str(self.dispspec) + "\n")
+def write_global_config(gui: GraphicUserInterface) -> None:
+    g = open(gui.cfgdir + "GLOBAL", "w")
+    g.write("config      " + str(int(gui.ui.showconf.isChecked())) + "\n")
+    g.write("projection  " + str(int(gui.ui.showproj.isChecked())) + "\n")
+    g.write("markers     " + str(int(gui.ui.showmarker.isChecked())) + "\n")
+    g.write("dispspec    " + str(gui.dispspec) + "\n")
     g.close()

--- a/camviewer_ui_impl.py
+++ b/camviewer_ui_impl.py
@@ -30,7 +30,6 @@ from PyQt5.QtWidgets import (
     QLabel,
     QMainWindow,
     QSpacerItem,
-    QLayout,
     QFileDialog,
     QMessageBox,
     QAction,
@@ -495,7 +494,9 @@ class GraphicUserInterface(QMainWindow):
         self.discoTimer.timeout.connect(self.do_disco)
 
         self.ui.average.returnPressed.connect(self.onAverageSet)
-        self.ui.comboBoxOrientation.currentIndexChanged.connect(self.onOrientationSelect)
+        self.ui.comboBoxOrientation.currentIndexChanged.connect(
+            self.onOrientationSelect
+        )
         self.ui.orient0.triggered.connect(lambda: self.setOrientation(param.ORIENT0))
         self.ui.orient90.triggered.connect(lambda: self.setOrientation(param.ORIENT90))
         self.ui.orient180.triggered.connect(
@@ -2198,7 +2199,7 @@ class GraphicUserInterface(QMainWindow):
             self.ui.showexpert.setChecked(False)
 
     def validDisplayFormat(self, rawString):
-        return re.match("^%\d+(\.\d*)?[efg]$", rawString) is not None
+        return re.match(r"^%\d+(\.\d*)?[efg]$", rawString) is not None
 
     def calibPVmon(self, exception=None):
         if exception is None:
@@ -2416,89 +2417,8 @@ class GraphicUserInterface(QMainWindow):
 
     def dumpConfig(self):
         if self.camera is not None and self.options is None:
-            f = open(self.cfgdir + self.cameraBase, "w")
-            g = open(self.cfgdir + "GLOBAL", "w")
-
-            f.write("projsize    " + str(self.projsize) + "\n")
-            f.write("viewwidth   " + str(self.viewwidth) + "\n")
-            f.write("viewheight  " + str(self.viewheight) + "\n")
-            g.write("config      " + str(int(self.ui.showconf.isChecked())) + "\n")
-            g.write("projection  " + str(int(self.ui.showproj.isChecked())) + "\n")
-            g.write("markers     " + str(int(self.ui.showmarker.isChecked())) + "\n")
-            f.write(
-                "portrait    " + str(int(param.orientation == param.ORIENT90)) + "\n"
-            )
-            f.write("orientation " + str(param.orientation) + "\n")
-            f.write(
-                "autorange   "
-                + str(int(self.ui.checkBoxProjAutoRange.isChecked()))
-                + "\n"
-            )
-            f.write("use_abs     1\n")
-            rz = self.ui.display_image.rectZoom.abs()
-            f.write(
-                "rectzoom    "
-                + str(rz.x())
-                + " "
-                + str(rz.y())
-                + " "
-                + str(rz.width())
-                + " "
-                + str(rz.height())
-                + "\n"
-            )
-            f.write("colormap    " + str(self.ui.comboBoxColor.currentText()) + "\n")
-            f.write("colorscale  " + str(self.ui.comboBoxScale.currentText()) + "\n")
-            f.write("colormin    " + self.ui.lineEditRangeMin.text() + "\n")
-            f.write("colormax    " + self.ui.lineEditRangeMax.text() + "\n")
-            f.write("grayscale   " + str(int(self.ui.grayScale.isChecked())) + "\n")
-            roi = self.ui.display_image.rectRoi.abs()
-            f.write(
-                "ROI         %d %d %d %d\n"
-                % (roi.x(), roi.y(), roi.width(), roi.height())
-            )
-            f.write("globmarks   " + str(int(self.useglobmarks)) + "\n")
-            f.write("globmarks2  " + str(int(self.useglobmarks2)) + "\n")
-            lMarker = self.ui.display_image.lMarker
-            for i in range(4):
-                f.write(
-                    "m%d          %d %d\n"
-                    % (i + 1, lMarker[i].abs().x(), lMarker[i].abs().y())
-                )
-            g.write("dispspec    " + str(self.dispspec) + "\n")
-            f.write(
-                "projroi     " + str(int(self.ui.checkBoxProjRoi.isChecked())) + "\n"
-            )
-            f.write(
-                "projlineout "
-                + str(int(self.ui.checkBoxM1Lineout.isChecked()))
-                + " "
-                + str(int(self.ui.checkBoxM2Lineout.isChecked()))
-                + " "
-                + str(int(self.ui.checkBoxM3Lineout.isChecked()))
-                + " "
-                + str(int(self.ui.checkBoxM4Lineout.isChecked()))
-                + "\n"
-            )
-            f.write("projfit     " + str(int(self.ui.checkBoxFits.isChecked())) + "\n")
-            f.write(
-                "projfittype "
-                + str(int(self.ui.radioGaussian.isChecked()))
-                + " "
-                + str(int(self.ui.radioSG4.isChecked()))
-                + " "
-                + str(int(self.ui.radioSG6.isChecked()))
-                + "\n"
-            )
-            f.write(
-                "projconstant " + str(int(self.ui.checkBoxConstant.isChecked())) + "\n"
-            )
-            f.write("projcalib   %g\n" % self.calib)
-            f.write('projcalibPV "%s"\n' % self.calibPVName)
-            f.write('projdisplayFormat "%s"\n' % self.displayFormat)
-
-            f.close()
-            g.close()
+            write_camera_config(self)
+            write_global_config(self)
 
             settings = QSettings("SLAC", "CamViewer")
             settings.setValue("geometry/%s" % self.cfgname, self.saveGeometry())
@@ -2789,3 +2709,77 @@ class GraphicUserInterface(QMainWindow):
             self.displayFormat = "%12.8g"
 
         self.cfg = None
+
+
+def write_camera_config(self: GraphicUserInterface) -> None:
+    f = open(self.cfgdir + self.cameraBase, "w")
+    f.write("projsize    " + str(self.projsize) + "\n")
+    f.write("viewwidth   " + str(self.viewwidth) + "\n")
+    f.write("viewheight  " + str(self.viewheight) + "\n")
+    f.write("portrait    " + str(int(param.orientation == param.ORIENT90)) + "\n")
+    f.write("orientation " + str(param.orientation) + "\n")
+    f.write("autorange   " + str(int(self.ui.checkBoxProjAutoRange.isChecked())) + "\n")
+    f.write("use_abs     1\n")
+    rz = self.ui.display_image.rectZoom.abs()
+    f.write(
+        "rectzoom    "
+        + str(rz.x())
+        + " "
+        + str(rz.y())
+        + " "
+        + str(rz.width())
+        + " "
+        + str(rz.height())
+        + "\n"
+    )
+    f.write("colormap    " + str(self.ui.comboBoxColor.currentText()) + "\n")
+    f.write("colorscale  " + str(self.ui.comboBoxScale.currentText()) + "\n")
+    f.write("colormin    " + self.ui.lineEditRangeMin.text() + "\n")
+    f.write("colormax    " + self.ui.lineEditRangeMax.text() + "\n")
+    f.write("grayscale   " + str(int(self.ui.grayScale.isChecked())) + "\n")
+    roi = self.ui.display_image.rectRoi.abs()
+    f.write("ROI         %d %d %d %d\n" % (roi.x(), roi.y(), roi.width(), roi.height()))
+    f.write("globmarks   " + str(int(self.useglobmarks)) + "\n")
+    f.write("globmarks2  " + str(int(self.useglobmarks2)) + "\n")
+    lMarker = self.ui.display_image.lMarker
+    for i in range(4):
+        f.write(
+            "m%d          %d %d\n" % (i + 1, lMarker[i].abs().x(), lMarker[i].abs().y())
+        )
+    f.write("projroi     " + str(int(self.ui.checkBoxProjRoi.isChecked())) + "\n")
+    f.write(
+        "projlineout "
+        + str(int(self.ui.checkBoxM1Lineout.isChecked()))
+        + " "
+        + str(int(self.ui.checkBoxM2Lineout.isChecked()))
+        + " "
+        + str(int(self.ui.checkBoxM3Lineout.isChecked()))
+        + " "
+        + str(int(self.ui.checkBoxM4Lineout.isChecked()))
+        + "\n"
+    )
+    f.write("projfit     " + str(int(self.ui.checkBoxFits.isChecked())) + "\n")
+    f.write(
+        "projfittype "
+        + str(int(self.ui.radioGaussian.isChecked()))
+        + " "
+        + str(int(self.ui.radioSG4.isChecked()))
+        + " "
+        + str(int(self.ui.radioSG6.isChecked()))
+        + "\n"
+    )
+    f.write("projconstant " + str(int(self.ui.checkBoxConstant.isChecked())) + "\n")
+    f.write("projcalib   %g\n" % self.calib)
+    f.write('projcalibPV "%s"\n' % self.calibPVName)
+    f.write('projdisplayFormat "%s"\n' % self.displayFormat)
+
+    f.close()
+
+
+def write_global_config(self: GraphicUserInterface) -> None:
+    g = open(self.cfgdir + "GLOBAL", "w")
+    g.write("config      " + str(int(self.ui.showconf.isChecked())) + "\n")
+    g.write("projection  " + str(int(self.ui.showproj.isChecked())) + "\n")
+    g.write("markers     " + str(int(self.ui.showmarker.isChecked())) + "\n")
+    g.write("dispspec    " + str(self.dispspec) + "\n")
+    g.close()

--- a/camviewer_ui_impl.py
+++ b/camviewer_ui_impl.py
@@ -2795,6 +2795,7 @@ def write_global_config(gui: GraphicUserInterface) -> None:
 def atomic_writer(path: str) -> typing.Iterator[typing.TextIO]:
     with tempfile.NamedTemporaryFile("w", delete=False) as fd:
         yield fd
+        # File must be closed before we can chmod and move it
         fd.close()
         # Set -rw-r--r-- instead of temp file default -rw-------
         os.chmod(fd.name, 0o644)

--- a/camviewer_ui_impl.py
+++ b/camviewer_ui_impl.py
@@ -2712,16 +2712,16 @@ class GraphicUserInterface(QMainWindow):
 
 
 def write_camera_config(gui: GraphicUserInterface) -> None:
-    f = open(gui.cfgdir + gui.cameraBase, "w")
-    f.write("projsize    " + str(gui.projsize) + "\n")
-    f.write("viewwidth   " + str(gui.viewwidth) + "\n")
-    f.write("viewheight  " + str(gui.viewheight) + "\n")
-    f.write("portrait    " + str(int(param.orientation == param.ORIENT90)) + "\n")
-    f.write("orientation " + str(param.orientation) + "\n")
-    f.write("autorange   " + str(int(gui.ui.checkBoxProjAutoRange.isChecked())) + "\n")
-    f.write("use_abs     1\n")
+    fd = open(gui.cfgdir + gui.cameraBase, "w")
+    fd.write("projsize    " + str(gui.projsize) + "\n")
+    fd.write("viewwidth   " + str(gui.viewwidth) + "\n")
+    fd.write("viewheight  " + str(gui.viewheight) + "\n")
+    fd.write("portrait    " + str(int(param.orientation == param.ORIENT90)) + "\n")
+    fd.write("orientation " + str(param.orientation) + "\n")
+    fd.write("autorange   " + str(int(gui.ui.checkBoxProjAutoRange.isChecked())) + "\n")
+    fd.write("use_abs     1\n")
     rz = gui.ui.display_image.rectZoom.abs()
-    f.write(
+    fd.write(
         "rectzoom    "
         + str(rz.x())
         + " "
@@ -2732,22 +2732,24 @@ def write_camera_config(gui: GraphicUserInterface) -> None:
         + str(rz.height())
         + "\n"
     )
-    f.write("colormap    " + str(gui.ui.comboBoxColor.currentText()) + "\n")
-    f.write("colorscale  " + str(gui.ui.comboBoxScale.currentText()) + "\n")
-    f.write("colormin    " + gui.ui.lineEditRangeMin.text() + "\n")
-    f.write("colormax    " + gui.ui.lineEditRangeMax.text() + "\n")
-    f.write("grayscale   " + str(int(gui.ui.grayScale.isChecked())) + "\n")
+    fd.write("colormap    " + str(gui.ui.comboBoxColor.currentText()) + "\n")
+    fd.write("colorscale  " + str(gui.ui.comboBoxScale.currentText()) + "\n")
+    fd.write("colormin    " + gui.ui.lineEditRangeMin.text() + "\n")
+    fd.write("colormax    " + gui.ui.lineEditRangeMax.text() + "\n")
+    fd.write("grayscale   " + str(int(gui.ui.grayScale.isChecked())) + "\n")
     roi = gui.ui.display_image.rectRoi.abs()
-    f.write("ROI         %d %d %d %d\n" % (roi.x(), roi.y(), roi.width(), roi.height()))
-    f.write("globmarks   " + str(int(gui.useglobmarks)) + "\n")
-    f.write("globmarks2  " + str(int(gui.useglobmarks2)) + "\n")
+    fd.write(
+        "ROI         %d %d %d %d\n" % (roi.x(), roi.y(), roi.width(), roi.height())
+    )
+    fd.write("globmarks   " + str(int(gui.useglobmarks)) + "\n")
+    fd.write("globmarks2  " + str(int(gui.useglobmarks2)) + "\n")
     lMarker = gui.ui.display_image.lMarker
     for i in range(4):
-        f.write(
+        fd.write(
             "m%d          %d %d\n" % (i + 1, lMarker[i].abs().x(), lMarker[i].abs().y())
         )
-    f.write("projroi     " + str(int(gui.ui.checkBoxProjRoi.isChecked())) + "\n")
-    f.write(
+    fd.write("projroi     " + str(int(gui.ui.checkBoxProjRoi.isChecked())) + "\n")
+    fd.write(
         "projlineout "
         + str(int(gui.ui.checkBoxM1Lineout.isChecked()))
         + " "
@@ -2758,8 +2760,8 @@ def write_camera_config(gui: GraphicUserInterface) -> None:
         + str(int(gui.ui.checkBoxM4Lineout.isChecked()))
         + "\n"
     )
-    f.write("projfit     " + str(int(gui.ui.checkBoxFits.isChecked())) + "\n")
-    f.write(
+    fd.write("projfit     " + str(int(gui.ui.checkBoxFits.isChecked())) + "\n")
+    fd.write(
         "projfittype "
         + str(int(gui.ui.radioGaussian.isChecked()))
         + " "
@@ -2768,18 +2770,18 @@ def write_camera_config(gui: GraphicUserInterface) -> None:
         + str(int(gui.ui.radioSG6.isChecked()))
         + "\n"
     )
-    f.write("projconstant " + str(int(gui.ui.checkBoxConstant.isChecked())) + "\n")
-    f.write("projcalib   %g\n" % gui.calib)
-    f.write('projcalibPV "%s"\n' % gui.calibPVName)
-    f.write('projdisplayFormat "%s"\n' % gui.displayFormat)
+    fd.write("projconstant " + str(int(gui.ui.checkBoxConstant.isChecked())) + "\n")
+    fd.write("projcalib   %g\n" % gui.calib)
+    fd.write('projcalibPV "%s"\n' % gui.calibPVName)
+    fd.write('projdisplayFormat "%s"\n' % gui.displayFormat)
 
-    f.close()
+    fd.close()
 
 
 def write_global_config(gui: GraphicUserInterface) -> None:
-    g = open(gui.cfgdir + "GLOBAL", "w")
-    g.write("config      " + str(int(gui.ui.showconf.isChecked())) + "\n")
-    g.write("projection  " + str(int(gui.ui.showproj.isChecked())) + "\n")
-    g.write("markers     " + str(int(gui.ui.showmarker.isChecked())) + "\n")
-    g.write("dispspec    " + str(gui.dispspec) + "\n")
-    g.close()
+    fd = open(gui.cfgdir + "GLOBAL", "w")
+    fd.write("config      " + str(int(gui.ui.showconf.isChecked())) + "\n")
+    fd.write("projection  " + str(int(gui.ui.showproj.isChecked())) + "\n")
+    fd.write("markers     " + str(int(gui.ui.showmarker.isChecked())) + "\n")
+    fd.write("dispspec    " + str(gui.dispspec) + "\n")
+    fd.close()

--- a/camviewer_ui_impl.py
+++ b/camviewer_ui_impl.py
@@ -2712,76 +2712,76 @@ class GraphicUserInterface(QMainWindow):
 
 
 def write_camera_config(gui: GraphicUserInterface) -> None:
-    fd = open(gui.cfgdir + gui.cameraBase, "w")
-    fd.write("projsize    " + str(gui.projsize) + "\n")
-    fd.write("viewwidth   " + str(gui.viewwidth) + "\n")
-    fd.write("viewheight  " + str(gui.viewheight) + "\n")
-    fd.write("portrait    " + str(int(param.orientation == param.ORIENT90)) + "\n")
-    fd.write("orientation " + str(param.orientation) + "\n")
-    fd.write("autorange   " + str(int(gui.ui.checkBoxProjAutoRange.isChecked())) + "\n")
-    fd.write("use_abs     1\n")
-    rz = gui.ui.display_image.rectZoom.abs()
-    fd.write(
-        "rectzoom    "
-        + str(rz.x())
-        + " "
-        + str(rz.y())
-        + " "
-        + str(rz.width())
-        + " "
-        + str(rz.height())
-        + "\n"
-    )
-    fd.write("colormap    " + str(gui.ui.comboBoxColor.currentText()) + "\n")
-    fd.write("colorscale  " + str(gui.ui.comboBoxScale.currentText()) + "\n")
-    fd.write("colormin    " + gui.ui.lineEditRangeMin.text() + "\n")
-    fd.write("colormax    " + gui.ui.lineEditRangeMax.text() + "\n")
-    fd.write("grayscale   " + str(int(gui.ui.grayScale.isChecked())) + "\n")
-    roi = gui.ui.display_image.rectRoi.abs()
-    fd.write(
-        "ROI         %d %d %d %d\n" % (roi.x(), roi.y(), roi.width(), roi.height())
-    )
-    fd.write("globmarks   " + str(int(gui.useglobmarks)) + "\n")
-    fd.write("globmarks2  " + str(int(gui.useglobmarks2)) + "\n")
-    lMarker = gui.ui.display_image.lMarker
-    for i in range(4):
+    with open(gui.cfgdir + gui.cameraBase, "w") as fd:
+        fd.write("projsize    " + str(gui.projsize) + "\n")
+        fd.write("viewwidth   " + str(gui.viewwidth) + "\n")
+        fd.write("viewheight  " + str(gui.viewheight) + "\n")
+        fd.write("portrait    " + str(int(param.orientation == param.ORIENT90)) + "\n")
+        fd.write("orientation " + str(param.orientation) + "\n")
         fd.write(
-            "m%d          %d %d\n" % (i + 1, lMarker[i].abs().x(), lMarker[i].abs().y())
+            "autorange   " + str(int(gui.ui.checkBoxProjAutoRange.isChecked())) + "\n"
         )
-    fd.write("projroi     " + str(int(gui.ui.checkBoxProjRoi.isChecked())) + "\n")
-    fd.write(
-        "projlineout "
-        + str(int(gui.ui.checkBoxM1Lineout.isChecked()))
-        + " "
-        + str(int(gui.ui.checkBoxM2Lineout.isChecked()))
-        + " "
-        + str(int(gui.ui.checkBoxM3Lineout.isChecked()))
-        + " "
-        + str(int(gui.ui.checkBoxM4Lineout.isChecked()))
-        + "\n"
-    )
-    fd.write("projfit     " + str(int(gui.ui.checkBoxFits.isChecked())) + "\n")
-    fd.write(
-        "projfittype "
-        + str(int(gui.ui.radioGaussian.isChecked()))
-        + " "
-        + str(int(gui.ui.radioSG4.isChecked()))
-        + " "
-        + str(int(gui.ui.radioSG6.isChecked()))
-        + "\n"
-    )
-    fd.write("projconstant " + str(int(gui.ui.checkBoxConstant.isChecked())) + "\n")
-    fd.write("projcalib   %g\n" % gui.calib)
-    fd.write('projcalibPV "%s"\n' % gui.calibPVName)
-    fd.write('projdisplayFormat "%s"\n' % gui.displayFormat)
-
-    fd.close()
+        fd.write("use_abs     1\n")
+        rz = gui.ui.display_image.rectZoom.abs()
+        fd.write(
+            "rectzoom    "
+            + str(rz.x())
+            + " "
+            + str(rz.y())
+            + " "
+            + str(rz.width())
+            + " "
+            + str(rz.height())
+            + "\n"
+        )
+        fd.write("colormap    " + str(gui.ui.comboBoxColor.currentText()) + "\n")
+        fd.write("colorscale  " + str(gui.ui.comboBoxScale.currentText()) + "\n")
+        fd.write("colormin    " + gui.ui.lineEditRangeMin.text() + "\n")
+        fd.write("colormax    " + gui.ui.lineEditRangeMax.text() + "\n")
+        fd.write("grayscale   " + str(int(gui.ui.grayScale.isChecked())) + "\n")
+        roi = gui.ui.display_image.rectRoi.abs()
+        fd.write(
+            "ROI         %d %d %d %d\n" % (roi.x(), roi.y(), roi.width(), roi.height())
+        )
+        fd.write("globmarks   " + str(int(gui.useglobmarks)) + "\n")
+        fd.write("globmarks2  " + str(int(gui.useglobmarks2)) + "\n")
+        lMarker = gui.ui.display_image.lMarker
+        for i in range(4):
+            fd.write(
+                "m%d          %d %d\n"
+                % (i + 1, lMarker[i].abs().x(), lMarker[i].abs().y())
+            )
+        fd.write("projroi     " + str(int(gui.ui.checkBoxProjRoi.isChecked())) + "\n")
+        fd.write(
+            "projlineout "
+            + str(int(gui.ui.checkBoxM1Lineout.isChecked()))
+            + " "
+            + str(int(gui.ui.checkBoxM2Lineout.isChecked()))
+            + " "
+            + str(int(gui.ui.checkBoxM3Lineout.isChecked()))
+            + " "
+            + str(int(gui.ui.checkBoxM4Lineout.isChecked()))
+            + "\n"
+        )
+        fd.write("projfit     " + str(int(gui.ui.checkBoxFits.isChecked())) + "\n")
+        fd.write(
+            "projfittype "
+            + str(int(gui.ui.radioGaussian.isChecked()))
+            + " "
+            + str(int(gui.ui.radioSG4.isChecked()))
+            + " "
+            + str(int(gui.ui.radioSG6.isChecked()))
+            + "\n"
+        )
+        fd.write("projconstant " + str(int(gui.ui.checkBoxConstant.isChecked())) + "\n")
+        fd.write("projcalib   %g\n" % gui.calib)
+        fd.write('projcalibPV "%s"\n' % gui.calibPVName)
+        fd.write('projdisplayFormat "%s"\n' % gui.displayFormat)
 
 
 def write_global_config(gui: GraphicUserInterface) -> None:
-    fd = open(gui.cfgdir + "GLOBAL", "w")
-    fd.write("config      " + str(int(gui.ui.showconf.isChecked())) + "\n")
-    fd.write("projection  " + str(int(gui.ui.showproj.isChecked())) + "\n")
-    fd.write("markers     " + str(int(gui.ui.showmarker.isChecked())) + "\n")
-    fd.write("dispspec    " + str(gui.dispspec) + "\n")
-    fd.close()
+    with open(gui.cfgdir + "GLOBAL", "w") as fd:
+        fd.write("config      " + str(int(gui.ui.showconf.isChecked())) + "\n")
+        fd.write("projection  " + str(int(gui.ui.showproj.isChecked())) + "\n")
+        fd.write("markers     " + str(int(gui.ui.showmarker.isChecked())) + "\n")
+        fd.write("dispspec    " + str(gui.dispspec) + "\n")


### PR DESCRIPTION
camviewer config files occasionally get corrupted.
This is likely because users can have multiple copies of the GUI open writing at the same time, non-atomically.

This PR cleans up the file writing so that the final file that ends up in the user's home area config is always placed there atomically via the operating system moving the file. The intermediate writes are applied to a temporary file. The final file is not moved unless it is complete (without exceptions).

In addition, the temporary file is managed with a context manager, which was not done before in this library, making it more likely to get cleaned up in the case of unrelated errors.

I moved the entire write block out of the class body and into the module body, despite still needing a reference to the entire gui object, because the function was already deeply nested and adding 2 context managers on top of that sounded like a maintenance hazard. So, instead, I apply the context managers separately and in the module scope to decrease the indentation pain.

This is similar to happi's atomic writes (https://github.com/pcdshub/happi/blob/e29373c8c09d91d642cd2a0cb0a8aed058754c55/happi/backends/json_db.py#L138-L151), except:
- I have no guarantee that the destination file already exists, so I can't copy mode and instead set a sensible mode manually
- I use the operating system's temp directory instead of making a file in the user's home
- I made a little context manager because I need to do this twice

I did not scrutinize the config file writing other than this specific attention to atomic writes. It's pretty clear there are other things to look at but I wanted to keep scope manageable.

Unrelated edits are appeasements of flake8