### PR TITLE
ENH: report errors, retry in saving camera image

### DIFF
--- a/camviewer_ui_impl.py
+++ b/camviewer_ui_impl.py
@@ -1177,8 +1177,13 @@ class GraphicUserInterface(QMainWindow):
             # QImage.save returned False, so the save failed.
             # Check for obvious errors, then retry the save
             # No write permissions?
-            directory = os.path.dirname(filename)
-            if not os.access(path=directory, mode=os.W_OK):
+            # If the file exists, we need to check the filename. Otherwise, we check the dirname.
+            if os.path.exists(filename):
+                can_write = os.access(path=filename, mode=os.W_OK)
+            else:
+                directory = os.path.dirname(filename)
+                can_write = os.access(path=directory, mode=os.W_OK)
+            if not can_write:
                 return self.warn_and_retry_save(
                     message=f"No permissions to write {filename}! Please pick a different location."
                 )

--- a/camviewer_ui_impl.py
+++ b/camviewer_ui_impl.py
@@ -1183,8 +1183,8 @@ class GraphicUserInterface(QMainWindow):
                     message=f"No permissions to write {filename}! Please pick a different location."
                 )
             # Invalid image type?
-            image_types = ["npy"] + [
-                qba.data().decode("utf-8")
+            image_types = [".npy"] + [
+                "." + qba.data().decode("utf-8")
                 for qba in QImageWriter.supportedImageFormats()
             ]
             if file_ext not in image_types:

--- a/camviewer_ui_impl.py
+++ b/camviewer_ui_impl.py
@@ -17,6 +17,7 @@ from dialogs import forcedialog
 
 import sys
 import os
+import os.path
 from pycaqtimage import pycaqtimage
 import pyca
 import math
@@ -1154,7 +1155,7 @@ class GraphicUserInterface(QMainWindow):
             filename = QFileDialog.getSaveFileName(
                 self,
                 "Save Image...",
-                self.cwd,
+                os.path.expanduser("~"),
                 "Images (*.npy *.jpg *.png *.bmp *.pgm *.tif)",
             )[0]
             if filename == "":

--- a/camviewer_ui_impl.py
+++ b/camviewer_ui_impl.py
@@ -1178,7 +1178,7 @@ class GraphicUserInterface(QMainWindow):
             else:
                 # QImage.save returned False, so the save failed.
                 # Check for obvious errors, then retry the save
-                # File already exists?
+                # File already exists? This shouldn't happen due to the qt file dialog.
                 if os.path.exists(filename):
                     reason = (
                         f"{filename} already exists! Please pick a different filename"
@@ -1195,6 +1195,8 @@ class GraphicUserInterface(QMainWindow):
                     else:
                         # Clean up the stub file we made
                         os.remove(filename)
+                        # I guess we have no idea what went wrong
+                        reason = "Unknown failure! Please try again."
                 QMessageBox.warning(
                     self,
                     "File Save Failed",

--- a/camviewer_ui_impl.py
+++ b/camviewer_ui_impl.py
@@ -17,7 +17,6 @@ from dialogs import forcedialog
 
 import sys
 import os
-import os.path
 from pycaqtimage import pycaqtimage
 import pyca
 import math

--- a/camviewer_ui_impl.py
+++ b/camviewer_ui_impl.py
@@ -185,6 +185,7 @@ class GraphicUserInterface(QMainWindow):
     param1Update = pyqtSignal()
     param2Update = pyqtSignal()
     timeoutExpiry = pyqtSignal()
+    retry_save_image = pyqtSignal()
 
     def __init__(
         self,
@@ -522,6 +523,7 @@ class GraphicUserInterface(QMainWindow):
         self.setOrientation(param.ORIENT0)  # default to use unrotated
 
         self.ui.FileSave.triggered.connect(self.onfileSave)
+        self.retry_save_image.connect(self.onfileSave)
 
         self.imageUpdate.connect(self.onImageUpdate)
         self.miscUpdate.connect(self.onMiscUpdate)
@@ -1202,7 +1204,7 @@ class GraphicUserInterface(QMainWindow):
                     "File Save Failed",
                     reason,
                 )
-                return self.onfileSave()
+                self.retry_save_image.emit()
         except Exception as e:
             print("fileSave failed:", e)
             QMessageBox.warning(self, "File Save Failed", str(e))


### PR DESCRIPTION
Related jira: https://jira.slac.stanford.edu/browse/ECS-6918

This PR's primary purpose is to fix a bug where the image saving dialog always reports success.

The reason for this is that `QImage.save` never raises, instead it returns `True` or `False` to signal if the image was saved properly. The original author of this bit of code assumed that the save function would raise with information about what went wrong.

This ends up being somewhat annoying, leaving it to us to figure out why the save might have failed.

Changes implemented here:

- Correctly check if `QImage.save` succeeded or failed
- If it failed, do a best-effort check for simple issues
- If it failed, ask the user to try a different filename and re-open the dialog
- Set the default directory to the user's home area, which is guaranteed to be writeable, unlike the current working directory
- fileName -> filename because the naming was irritating me