### PR TITLE
FIX: set max row count to avoid iterating off the end of the data buffer

### DIFF
--- a/camviewer_ui_impl.py
+++ b/camviewer_ui_impl.py
@@ -1991,6 +1991,22 @@ class GraphicUserInterface(QMainWindow):
         # Get camera configuration
         self.getConfig()
 
+        # Check the expected size against the count to generate warnings
+        first_image_count = len(self.camera.value)
+        expected_count = self.rowPv.value * self.colPv.value
+        if first_image_count != expected_count:
+            QMessageBox.warning(
+                None,
+                "Warning",
+                (
+                    "IOC misconfiguration likely!\n"
+                    f"Received {first_image_count} pixels, expected {expected_count} "
+                    f"for {self.rowPv.value} x {self.colPv.value}."
+                ),
+                QMessageBox.Ok,
+                QMessageBox.Ok,
+            )
+
     def setCameraMenu(self, index):
         for a in self.camactions:
             a.setChecked(False)

--- a/pycaqtimage/pycaqtimage.sip
+++ b/pycaqtimage/pycaqtimage.sip
@@ -349,8 +349,17 @@ static int rowIncMult1[8] = {  0,   0,  -1,  -1,   0,   0,   1,   1}; /* Scaled 
 static int rowIncMult2[8] = {  0,   2,   0,   0,   0,  -2,   0,   0}; /* Scaled by srcwidth */
 static int rowIncK[8]     = {  0,   0,  -1,   1,   0,   0,   1,  -1}; /* Constant */
 
+int _max_row(ImageBuffer *imageBuffer, long count)
+{
+    if (imageBuffer->imgwidth > 0) {
+        return std::min(imageBuffer->imgheight, (int) std::floor(count / imageBuffer->imgwidth));
+    } else {
+        return 0;
+    }
+}
+
 template <class T>
-void _pyDoAvg(ImageBuffer *imageBuffer, T *cadata)
+void _pyDoAvg(ImageBuffer *imageBuffer, T *cadata, long count)
 {
     T *src           = cadata;
     uint32_t *dst    = imageBuffer->imageData;
@@ -365,10 +374,11 @@ void _pyDoAvg(ImageBuffer *imageBuffer, T *cadata)
     int col_inc      = imageBuffer->srcwidth * colIncMult[orientation] +
                        colIncK[orientation];
     int iNewAverage  = imageBuffer->iNumAveraged + 1;
+    int row_max = _max_row(imageBuffer, count);
 
     src += init_offset;
     if (iNewAverage == 1) {
-	for (int iRow = 0; iRow < imageBuffer->imgheight; ++iRow) {
+	for (int iRow = 0; iRow < row_max; ++iRow) {
 	    for (int iCol = 0; iCol < imageBuffer->imgwidth; ++iCol) {
 		*dstF++ = *src;
 		*dst++ = *src;
@@ -377,7 +387,7 @@ void _pyDoAvg(ImageBuffer *imageBuffer, T *cadata)
 	    src += row_inc;
 	}
     } else {
-	for (int iRow = 0; iRow < imageBuffer->imgheight; ++iRow) {
+	for (int iRow = 0; iRow < row_max; ++iRow) {
 	    for (int iCol = 0; iCol < imageBuffer->imgwidth; ++iCol) {
 		*dstF += (*src - *dstF) / iNewAverage;
 		*dst++ = *dstF++;
@@ -408,14 +418,14 @@ static void _pyColorImagePvCallback(void* cadata, long count, size_t size, void*
     int col_inc      = imageBuffer->srcwidth * colIncMult[orientation] +
                        colIncK[orientation];
     int iNewAverage  = imageBuffer->iNumAveraged + 1;
+    int row_max = _max_row(imageBuffer, count);
 
-    UNUSED(count);
     UNUSED(size);
 
     /* If we're using the color image, don't average, just copy and we're done! */
     if (!imageBuffer->useGray) {
         src += 3 * init_offset;
-	for (int iRow = 0; iRow < imageBuffer->imgheight; ++iRow) {
+	for (int iRow = 0; iRow < row_max; ++iRow) {
 	    for (int iCol = 0; iCol < imageBuffer->imgwidth; ++iCol) {
 		*dst++ = RGB(src);
 		src += 3 * col_inc;
@@ -426,7 +436,7 @@ static void _pyColorImagePvCallback(void* cadata, long count, size_t size, void*
     } else {
 	if (iNewAverage == 1) {
             src += 3 * init_offset;
-	    for (int iRow = 0; iRow < imageBuffer->imgheight; ++iRow) {
+	    for (int iRow = 0; iRow < row_max; ++iRow) {
 		for (int iCol = 0; iCol < imageBuffer->imgwidth; ++iCol) {
 		    *dstF = GRAY(src);
 		    *dst++ = *dstF++;
@@ -436,7 +446,7 @@ static void _pyColorImagePvCallback(void* cadata, long count, size_t size, void*
 	    }
 	} else {
             src += 3 * init_offset;
-	    for (int iRow = 0; iRow < imageBuffer->imgheight; ++iRow) {
+	    for (int iRow = 0; iRow < row_max; ++iRow) {
 		for (int iCol = 0; iCol < imageBuffer->imgwidth; ++iCol) {
 		    *dstF += (GRAY(src) - *dstF) / iNewAverage;
 		    *dst++ = *dstF++;
@@ -456,16 +466,15 @@ static void _pyImagePvCallback(void* cadata, long count, size_t size, void* usr)
 {
   ImageBuffer*  imageBuffer = reinterpret_cast<ImageBuffer*>(usr);
 
-  UNUSED(count);
   switch (size) {
     case 4:
-	_pyDoAvg(imageBuffer, reinterpret_cast<uint32_t*>(cadata));
+	_pyDoAvg(imageBuffer, reinterpret_cast<uint32_t*>(cadata), count);
         break;
     case 2:
-	_pyDoAvg(imageBuffer, reinterpret_cast<uint16_t*>(cadata));
+	_pyDoAvg(imageBuffer, reinterpret_cast<uint16_t*>(cadata), count);
         break;
     case 1:
-	_pyDoAvg(imageBuffer, reinterpret_cast<uint8_t*>(cadata));
+	_pyDoAvg(imageBuffer, reinterpret_cast<uint8_t*>(cadata), count);
         break;
     default:
         fprintf(stderr, "Image pixel size is %d bytes?\n", (int) size);


### PR DESCRIPTION
## For reviewers

I'm not quite ready to deploy this but I'd like opinions from people who have experience writing C++.
I'd particularly like tips or ideas for doing this more intelligently.

## Description

There's a rare bug that deals with improperly-configured cameras. I suspect it also could happen as a race condition on a camera resize.

This bug manifests itself when the "count" of the epics array is shorter than the total number of pixels. In some cases this results in garbage data making it into the image, in other cases this results in a segfault.

This update aims to add minimal processing overhead to the new array processor while stopping it from iterating past the end of the data buffer. It does this by using the previously unused "count" long from pyca which tells us how many data elements there are, and doing a quick one-time calculation of the max row we can get to without exhausting the buffer. Then we sub this number in for the row count in the iteration and stop right after the final row.

This works in my toy example I cooked up and it doesn't crash the GUI, but before merging I'd need to intentionally misconfigure a camera to check what the behavior ends up being.