### PR TITLE
FIX: fix error in recolor logic and simplify

### DIFF
--- a/pycaqtimage/pycaqtimage.sip
+++ b/pycaqtimage/pycaqtimage.sip
@@ -329,9 +329,10 @@ static void _pyCopyToQImage(ImageBuffer* imageBuffer, int doFC)
 PyObject* pyRecolorImageBuffer(PyObject* pyImageBuffer)
 {
     ImageBuffer* imageBuffer = (ImageBuffer*) PyCapsule_GetPointer(pyImageBuffer, PYC_IB);
-    /* If the image is supposed to be color or if we're averaging, skip it! */
-    if ((imageBuffer->isColor && !imageBuffer->useGray) || imageBuffer->iAverage != 1)
-	_pyCopyToQImage(imageBuffer, 1);
+    // Skip color images, which causes a black image flash
+    if (!imageBuffer->isColor || imageBuffer->useGray) {
+	    _pyCopyToQImage(imageBuffer, 1);
+    }
     Py_RETURN_NONE;
 }
 


### PR DESCRIPTION
There is a sip-wrapped C++ function that the GUI calls when it needs to recolor an image that was already rendered. It does this, for example, when the user changes the color map or adjusts the min/max pixel value sliders so that stale images are recolored live.

There was a bug reported that this doesn't actually work (https://jira.slac.stanford.edu/browse/ECS-7015)
and upon further investigation, the logic was wrong.

The original code had a comment indicating that the recolor should be skipped for color cams and when averaging was on.
Then, it had an if statement that did exactly the opposite: recolor would only be done for color cams and when averaging was on.

I ended up fixing and then simplifying the check to only exclude color cams. Including averages is useful because when you average e.g. 100 frames it can take a long time before you get the next image, so it's nice to see the colors update live. Excluding color cams is important because it makes the screen flash black.