### PR TITLE
ENH: auto range for min/max sliders

### DIFF
--- a/camviewer.ui
+++ b/camviewer.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1119</width>
-    <height>1075</height>
+    <width>1106</width>
+    <height>1070</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -798,38 +798,6 @@ Vmin\</string>
          <string>Color Map</string>
         </property>
         <layout class="QGridLayout" name="gridLayout_4">
-         <item row="0" column="0" colspan="2">
-          <widget class="QComboBox" name="comboBoxColor">
-           <property name="currentIndex">
-            <number>1</number>
-           </property>
-           <item>
-            <property name="text">
-             <string>HSV</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Hot</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Jet</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Cool</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Gray</string>
-            </property>
-           </item>
-          </widget>
-         </item>
          <item row="0" column="3">
           <widget class="QComboBox" name="comboBoxScale">
            <item>
@@ -869,6 +837,38 @@ Vmin\</string>
            </item>
           </widget>
          </item>
+         <item row="0" column="0" colspan="2">
+          <widget class="QComboBox" name="comboBoxColor">
+           <property name="currentIndex">
+            <number>1</number>
+           </property>
+           <item>
+            <property name="text">
+             <string>HSV</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Hot</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Jet</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Cool</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Gray</string>
+            </property>
+           </item>
+          </widget>
+         </item>
          <item row="1" column="0">
           <widget class="QLabel" name="labelRangeMin">
            <property name="text">
@@ -895,6 +895,30 @@ Vmin\</string>
            </property>
            <property name="tickInterval">
             <number>256</number>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="3">
+          <widget class="QLineEdit" name="lineEditRangeMax">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>1</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>100</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="font">
+            <font>
+             <pointsize>8</pointsize>
+            </font>
+           </property>
+           <property name="text">
+            <string>1023</string>
            </property>
           </widget>
          </item>
@@ -960,34 +984,24 @@ Vmin\</string>
            </property>
           </widget>
          </item>
-         <item row="2" column="3">
-          <widget class="QLineEdit" name="lineEditRangeMax">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-             <horstretch>1</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>100</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="font">
-            <font>
-             <pointsize>8</pointsize>
-            </font>
-           </property>
-           <property name="text">
-            <string>1023</string>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="0" colspan="4">
+         <item row="4" column="0" colspan="4">
           <widget class="QCheckBox" name="grayScale">
            <property name="text">
             <string>Force Color Image to Grayscale</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="3">
+          <widget class="QPushButton" name="pushbutton_auto_range">
+           <property name="text">
+            <string>Auto Once</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0" colspan="2">
+          <widget class="QCheckBox" name="checkbox_auto_range">
+           <property name="text">
+            <string>Auto every frame</string>
            </property>
           </widget>
          </item>
@@ -2242,7 +2256,7 @@ Vmin\</string>
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>1119</width>
+     <width>1106</width>
      <height>20</height>
     </rect>
    </property>

--- a/camviewer_ui_impl.py
+++ b/camviewer_ui_impl.py
@@ -2540,8 +2540,8 @@ class GraphicUserInterface(QMainWindow):
         from the last collected image and sets them as the maximum
         and minimum pixel thresholds for the colormap.
 
-        This is intended to be called as a callback from clicking a
-        QPushButton or from checking a QCheckbox.
+        This is intended to be called as a slot from signals emitted
+        from clicking a QPushButton or from checking a QCheckbox.
 
         If the QPushButton is clicked or the QCheckbox is checked,
         immediately apply an automatic range to the live image.

--- a/camviewer_ui_impl.py
+++ b/camviewer_ui_impl.py
@@ -1430,17 +1430,14 @@ class GraphicUserInterface(QMainWindow):
                 roiVarByMean = roiVar / roiMean
             roi = self.ui.display_image.rectRoi.oriented()
             self.ui.labelRoiInfo.setText(
-                "ROI Mean %-7.2f Std %-7.2f Var/Mean %-7.2f Min %d Max %d (%d,%d) W %d H %d"
-                % (
-                    roiMean,
-                    math.sqrt(roiVar),
-                    roiVarByMean,
-                    self.min_px,
-                    self.max_px,
-                    roi.x(),
-                    roi.y(),
-                    roi.width(),
-                    roi.height(),
+                (
+                    f"ROI Mean {roiMean:<-7.2f} "
+                    f"Std {math.sqrt(roiVar):<-7.2f} "
+                    f"Var/Mean {roiVarByMean:<-7.2f} "
+                    f"Min {self.min_px:<4d} "
+                    f"Max {self.max_px:<4d} "
+                    f"({roi.x()},{roi.y()}) "
+                    f"W {roi.width()} H {roi.height()}"
                 )
             )
             self.ui.labelProjHmax.setText("%d -" % projXmax)

--- a/camviewer_ui_impl.py
+++ b/camviewer_ui_impl.py
@@ -405,6 +405,9 @@ class GraphicUserInterface(QMainWindow):
         self.updateRoiText()
         self.updateMarkerText(True, True, 0, 15)
 
+        self.max_px = 0
+        self.min_px = 0
+
         sizeProjX = QSize(self.viewwidth, self.projsize)
         self.ui.projH.doResize(sizeProjX)
 
@@ -1378,6 +1381,8 @@ class GraphicUserInterface(QMainWindow):
                 projXmax,
                 projYmin,
                 projYmax,
+                self.max_px,
+                self.min_px,
             ) = pycaqtimage.pyUpdateProj(
                 self.imageBuffer,
                 self.ui.checkBoxProjAutoRange.isChecked(),
@@ -1385,6 +1390,7 @@ class GraphicUserInterface(QMainWindow):
                 self.iRangeMax,
                 self.ui.display_image.rectRoi.oriented(),
             )
+            print(self.min_px, self.max_px)
             (projXmin, projXmax) = self.ui.projH.makeImage(
                 projXmin, projXmax, projYmin, projYmax
             )

--- a/camviewer_ui_impl.py
+++ b/camviewer_ui_impl.py
@@ -2967,10 +2967,11 @@ class GraphicUserInterface(QMainWindow):
             self.cfg.colorscale[0] + " " + self.cfg.colorscale[1]
         )
         self.ui.comboBoxScale.setCurrentIndex(self.iScaleIndex)
-        self.ui.lineEditRangeMin.setText(self.cfg.colormin)
-        self.on_range_min_text_enter_pressed()
-        self.ui.lineEditRangeMax.setText(self.cfg.colormax)
-        self.on_range_max_text_enter_pressed()
+        try:
+            self.set_new_min_pixel(int(self.cfg.colormin))
+            self.set_new_max_pixel(int(self.cfg.colormax))
+        except Exception:
+            print("Failed to load min or max pixel value from config file.")
         try:
             self.ui.grayScale.setChecked(int(self.cfg.grayscale))
             self.onCheckGrayUpdate(int(self.cfg.grayscale))

--- a/camviewer_ui_impl.py
+++ b/camviewer_ui_impl.py
@@ -2509,7 +2509,7 @@ class GraphicUserInterface(QMainWindow):
         """
         When the user lets go of the slider, update the value and rerender.
         """
-        self.set_new_min_pixel(self.ui.horizontalSliderRangeMax.value())
+        self.set_new_max_pixel(self.ui.horizontalSliderRangeMax.value())
         self.after_new_min_or_max_pixel()
 
     def onSliderLensChanged(self, newSliderValue):

--- a/camviewer_ui_impl.py
+++ b/camviewer_ui_impl.py
@@ -423,13 +423,17 @@ class GraphicUserInterface(QMainWindow):
         self.ui.checkBoxProjAutoRange.stateChanged.connect(self.onCheckProjUpdate)
 
         self.ui.horizontalSliderRangeMin.sliderReleased.connect(
-            self.onSliderRangeMinReleased
+            self.on_slider_range_min_released
         )
         self.ui.horizontalSliderRangeMax.sliderReleased.connect(
-            self.onSliderRangeMaxReleased
+            self.on_slider_range_max_released
         )
-        self.ui.lineEditRangeMin.returnPressed.connect(self.onRangeMinTextEnter)
-        self.ui.lineEditRangeMax.returnPressed.connect(self.onRangeMaxTextEnter)
+        self.ui.lineEditRangeMin.returnPressed.connect(
+            self.on_range_min_text_enter_pressed
+        )
+        self.ui.lineEditRangeMax.returnPressed.connect(
+            self.on_range_max_text_enter_pressed
+        )
         self.ui.pushbutton_auto_range.pressed.connect(self.set_auto_range)
         self.ui.checkbox_auto_range.stateChanged.connect(self.set_auto_range)
 
@@ -2498,14 +2502,14 @@ class GraphicUserInterface(QMainWindow):
         self.ui.lineEditRangeMax.setText(str(self.iRangeMax))
         self.ui.lineEditRangeMin.setText(str(self.iRangeMin))
 
-    def onSliderRangeMinReleased(self):
+    def on_slider_range_min_released(self):
         """
         When the user lets go of the slider, update the value and rerender.
         """
         self.set_new_min_pixel(self.ui.horizontalSliderRangeMin.value())
         self.after_new_min_or_max_pixel()
 
-    def onSliderRangeMaxReleased(self):
+    def on_slider_range_max_released(self):
         """
         When the user lets go of the slider, update the value and rerender.
         """
@@ -2529,7 +2533,7 @@ class GraphicUserInterface(QMainWindow):
             except pyca.caexc as e:
                 print("channel access exception: %s" % (e))
 
-    def onRangeMinTextEnter(self):
+    def on_range_min_text_enter_pressed(self):
         """
         When the user presses enter on the pixel text boxes, update the value and rerender.
         """
@@ -2540,7 +2544,7 @@ class GraphicUserInterface(QMainWindow):
         self.set_new_min_pixel(value)
         self.after_new_min_or_max_pixel()
 
-    def onRangeMaxTextEnter(self):
+    def on_range_max_text_enter_pressed(self):
         """
         When the user presses enter on the pixel text boxes, update the value and rerender.
         """
@@ -2964,9 +2968,9 @@ class GraphicUserInterface(QMainWindow):
         )
         self.ui.comboBoxScale.setCurrentIndex(self.iScaleIndex)
         self.ui.lineEditRangeMin.setText(self.cfg.colormin)
-        self.onRangeMinTextEnter()
+        self.on_range_min_text_enter_pressed()
         self.ui.lineEditRangeMax.setText(self.cfg.colormax)
-        self.onRangeMaxTextEnter()
+        self.on_range_max_text_enter_pressed()
         try:
             self.ui.grayScale.setChecked(int(self.cfg.grayscale))
             self.onCheckGrayUpdate(int(self.cfg.grayscale))

--- a/pycaqtimage/pycaqtimage.sip
+++ b/pycaqtimage/pycaqtimage.sip
@@ -510,7 +510,7 @@ static void _computeRoiProj(ImageBuffer* imageBuffer, QRectF* rectRoi, bool bPro
     int       width     = imageBuffer->imgwidth;
     int       height    = imageBuffer->imgheight;
     uint32_t  max_px    = 0;
-    uint32_t  min_px    = 4294967295;
+    uint32_t  min_px    = std::numeric_limits<uint32_t>::max();
 
     for (int iX = 0; iX < width;  projSumX[iX++] = 0);
     for (int iY = 0; iY < height; projSumY[iY++] = 0);

--- a/pycaqtimage/pycaqtimage.sip
+++ b/pycaqtimage/pycaqtimage.sip
@@ -159,6 +159,7 @@ struct ImageBuffer
     int       imgwidth, imgheight;
     int       size;
     int       iRoiW, iRoiH;
+    uint32_t  max_px, min_px;
 
     int32_t  iProjXmin, iProjXmax;
     int32_t  iProjYmin, iProjYmax;
@@ -271,6 +272,8 @@ PyObject* pyCreateImageBuffer(QImage* imageDisp, PyObject *px_, PyObject *py_, P
     memset(imageBuffer->projSumY, 0, leny * sizeof(double) );
     memset(imageBuffer->imageData, 0, imageBuffer->size * sizeof(uint32_t) );
     memset(imageBuffer->imageDataF, 0, imageBuffer->size * sizeof(float) );
+    imageBuffer->max_px = 0;
+    imageBuffer->min_px = 0;
 
     PyObject* pyImageBuffer = PyCapsule_New(imageBuffer, PYC_IB, _pyFreeImageBuffer);
     return pyImageBuffer;
@@ -506,6 +509,8 @@ static void _computeRoiProj(ImageBuffer* imageBuffer, QRectF* rectRoi, bool bPro
     double*   projSumY  = imageBuffer->projSumY;
     int       width     = imageBuffer->imgwidth;
     int       height    = imageBuffer->imgheight;
+    uint32_t  max_px    = 0;
+    uint32_t  min_px    = 4294967295;
 
     for (int iX = 0; iX < width;  projSumX[iX++] = 0);
     for (int iY = 0; iY < height; projSumY[iY++] = 0);
@@ -557,8 +562,13 @@ static void _computeRoiProj(ImageBuffer* imageBuffer, QRectF* rectRoi, bool bPro
 	    u64PixelSum   += iValue;
 	    /* Sigh... if iValue > 49000 or so, the square of an int will be negative! */
 	    u64PixelSqSum += iValue*(uint64_t) iValue;
+        max_px = std::max(iValue, max_px);
+        min_px = std::min(iValue, min_px);
 	}
     }
+
+    imageBuffer->max_px = max_px;
+    imageBuffer->min_px = min_px;
 
     imageBuffer->iRoiW = x2 - x1 + 1;
     imageBuffer->iRoiH = y2 - y1 + 1;
@@ -641,8 +651,17 @@ PyObject* pyUpdateProj(PyObject* pyImageBuffer, bool bProjAutoRange,
         imageBuffer->iProjYmax = uMax;
     }
 
-    return Py_BuildValue("ffiiii", imageBuffer->fRoiPixelMean, imageBuffer->fRoiPixelVar,
-                         imageBuffer->iProjXmin, imageBuffer->iProjXmax, imageBuffer->iProjYmin, imageBuffer->iProjYmax);
+    return Py_BuildValue(
+        "ffiiiiii",
+        imageBuffer->fRoiPixelMean,
+        imageBuffer->fRoiPixelVar,
+        imageBuffer->iProjXmin,
+        imageBuffer->iProjXmax,
+        imageBuffer->iProjYmin,
+        imageBuffer->iProjYmax,
+        imageBuffer->max_px,
+        imageBuffer->min_px
+    );
 }
 
 /*


### PR DESCRIPTION
Part of https://jira.slac.stanford.edu/browse/ECS-7005

Main changes:
- Calculate the min/max pixel in the ROI on each frame. I added this to the C++ code in the same block where we calculate other statistics about the ROI.
- Add button to set the min/max of the color map range to these values. This could be used to narrow the range once before further manual tuning of the color range.
- Add checkbox to automatically update the min/max color map ranges on each frame. This could be used to continuously adjust the color range for changing input intensities.

Related internal changes:
- Rework the various range widgets to only apply their changes when the user causes a change. This allows us to have separate dedicated internal functions for updating the related internal attributes and another set of functions for updating the UI display of these values that doesn't cause an infinite loop.

![image](https://github.com/user-attachments/assets/2c585874-b23e-4183-b383-db46a80335f4)
