### PR TITLE
FIX: close monitors at app exit to avoid shutdown core dumps

### DIFF
--- a/camviewer_ui_impl.py
+++ b/camviewer_ui_impl.py
@@ -654,6 +654,7 @@ class GraphicUserInterface(QMainWindow):
         self.efilter = FilterObject(self.app, self)
 
     def closeEvent(self, event):
+        self.end_monitors()
         if self.cameraBase != "":
             self.activeClear()
         if self.haveforce and self.forcedialog is not None:
@@ -664,6 +665,24 @@ class GraphicUserInterface(QMainWindow):
         if self.cfg is None:
             self.dumpConfig()
         QMainWindow.closeEvent(self, event)
+
+    def end_monitors(self):
+        all_mons = []
+        all_mons.extend(self.camconn_pvs)
+        all_mons.extend(self.globmarkpvs)
+        all_mons.extend(self.globmarkpvs2)
+        all_mons.extend(self.otherpvs)
+        all_mons.append(self.notify)
+        all_mons.append(self.rowPv)
+        all_mons.append(self.colPv)
+        all_mons.append(self.launch_gui_pv)
+        all_mons.append(self.launch_edm_pv)
+        all_mons.append(self.lensPv)
+        all_mons.append(self.calibPV)
+        for pv in all_mons:
+            if pv is not None:
+                pv.monitor_stop()
+        pyca.flush_io()
 
     def setImageSize(self, newx, newy, reset=True):
         if newx == 0 or newy == 0:


### PR DESCRIPTION
After #23, where I added a lot of monitors, there were core dumps at shutdown most times I closed the app.

When you inspect these core dumps, you'd see that what's going on is that the app is terminating during the process of a pyca epics callback, raising an exception in the c++ code, and then dropping a core dump into `/tmp`.

This PR collects all the monitored PVs during the close event and stops all the monitors, guaranteeing that the monitor callbacks will not be running when the application fully closes and the PV objects are garbage collected.

To test, I used xcs this time because they have a bunch of online cams (and someone turned off all the laser IOCs)

```
./run_viewer_local.sh --instrument xcs --pvlist /cds/group/pcds/pyps/config/xcs/camviewer.cfg
```

Without the patch, I opened and closed the app 5 times and got 5 core dumps.
With the patch, I opened and closed the app ~15 times and got 0 core dumps. 

Ref https://jira.slac.stanford.edu/browse/ECS-7016