### PR TITLE
ENH: cam-specific controls

### DIFF
--- a/cam_types.py
+++ b/cam_types.py
@@ -21,7 +21,7 @@ STOP_TEXT = "Stopped"
 START_TEXT = "Started"
 
 
-class ModelScreenGenerator(QObject):
+class CamTypeScreenGenerator(QObject):
     """
     This class creates a cam-specific QFormLayout to include in the main screen.
 

--- a/cam_types.py
+++ b/cam_types.py
@@ -14,7 +14,14 @@ from threading import Lock
 
 from psp.Pv import Pv
 from PyQt5.QtCore import QObject, pyqtSignal
-from PyQt5.QtWidgets import QFormLayout, QLabel, QPushButton, QHBoxLayout, QSpinBox
+from PyQt5.QtWidgets import (
+    QFormLayout,
+    QLabel,
+    QPushButton,
+    QHBoxLayout,
+    QSpinBox,
+    QMessageBox,
+)
 
 
 STOP_TEXT = "Stopped"
@@ -127,7 +134,14 @@ class CamTypeScreenGenerator(QObject):
             return
         else:
             print(f"Loading special screen for {self.full_name}")
-        finisher_pvs, finisher_sigs = finisher(self.form, self.base_pv)
+        try:
+            finisher_pvs, finisher_sigs = finisher(self.form, self.base_pv)
+        except Exception as exc:
+            QMessageBox.warning(
+                self.parent(),
+                "Internal error",
+                f"Error loading model-specific widgets for {self.full_name}: {exc}",
+            )
         self.pvs_to_clean_up.extend(finisher_pvs)
         self.sigs_to_clean_up.extend(finisher_sigs)
 

--- a/cam_types.py
+++ b/cam_types.py
@@ -84,7 +84,7 @@ class CamTypeScreenGenerator(QObject):
         )
         self.pvs_to_clean_up.append(self.acq_status_pv)
         self.acq_set_pv = Pv(f"{base_pv}:Acquire")
-        self.acq_set_pv.add_rwaccess_callback(self.acq_rw_acc)
+        self.acq_set_pv.add_rwaccess_callback(self.acquire_rw_cb)
         self.acq_set_pv.do_initialize = True
         self.acq_set_pv.do_monitor = True
         self.acq_set_pv.connect()
@@ -201,7 +201,7 @@ class CamTypeScreenGenerator(QObject):
         except Exception:
             ...
 
-    def acq_rw_acc(self, _: bool, write_access: bool) -> None:
+    def acquire_rw_cb(self, _: bool, write_access: bool) -> None:
         """
         Read/write access callback for enabling/disabling the acquire buttons.
 

--- a/cam_types.py
+++ b/cam_types.py
@@ -194,6 +194,7 @@ def em_gain_andor(form: QFormLayout, base_pv: str) -> tuple[list[Pv], list[pyqtS
 
     gain_spinbox = QSpinBox()
     gain_spinbox.setMaximum(10000000)
+    gain_spinbox.setEnabled(False)
 
     gain_layout = QHBoxLayout()
     gain_layout.addWidget(gain_label)
@@ -206,12 +207,18 @@ def em_gain_andor(form: QFormLayout, base_pv: str) -> tuple[list[Pv], list[pyqtS
             gain_label.setText(str(gain_rbv_pv.value))
             gain_spinbox.setValue(int(gain_rbv_pv.value))
 
+    def gain_rw_cb(_: bool, write_access: bool):
+        gain_spinbox.setEnabled(write_access)
+
     gain_rbv_pv = Pv(
         f"{base_pv}:AndorEMGain_RBV",
         monitor=update_gain_widgets,
         initialize=True,
     )
     gain_set_pv = Pv(f"{base_pv}:AndorEMGain")
+    gain_set_pv.add_rwaccess_callback(gain_rw_cb)
+    gain_set_pv.do_initialize = True
+    gain_set_pv.do_monitor = True
     gain_set_pv.connect()
     pvs.append(gain_rbv_pv)
     pvs.append(gain_set_pv)

--- a/cam_types.py
+++ b/cam_types.py
@@ -167,36 +167,39 @@ def em_gain_andor(form: QFormLayout, base_pv: str) -> tuple[list[Pv], list[pyqtS
 
     gain_label = QLabel()
 
-    def update_gain_label(error: Exception | None):
-        if error is None:
-            gain_label.setText(str(gain_rbv_pv.value))
-
-    gain_rbv_pv = Pv(
-        f"{base_pv}:AndorEMGain_RBV",
-        monitor=update_gain_label,
-        initialize=True,
-    )
-    pvs.append(gain_rbv_pv)
-
-    gain_set_pv = Pv(f"{base_pv}:AndorEMGain")
-    pvs.append(gain_set_pv)
-    gain_set_pv.connect()
-
-    def set_gain_value():
-        try:
-            gain_set_pv.put(gain_spinbox.value())
-        except Exception:
-            ...
-
     gain_spinbox = QSpinBox()
     gain_spinbox.setMaximum(10000000)
-    gain_spinbox.editingFinished.connect(set_gain_value)
-    sigs.append(gain_spinbox.editingFinished)
 
     gain_layout = QHBoxLayout()
     gain_layout.addWidget(gain_label)
     gain_layout.addWidget(gain_spinbox)
+
     form.addRow("EM Gain", gain_layout)
+
+    def update_gain_widgets(error: Exception | None):
+        if error is None:
+            gain_label.setText(str(gain_rbv_pv.value))
+            gain_spinbox.setValue(int(gain_rbv_pv.value))
+
+    gain_rbv_pv = Pv(
+        f"{base_pv}:AndorEMGain_RBV",
+        monitor=update_gain_widgets,
+        initialize=True,
+    )
+    gain_set_pv = Pv(f"{base_pv}:AndorEMGain")
+    gain_set_pv.connect()
+    pvs.append(gain_rbv_pv)
+    pvs.append(gain_set_pv)
+
+    def set_gain_value():
+        try:
+            gain_set_pv.put(gain_spinbox.value())
+        except Exception as exc:
+            print(f"Error updating EM gain PV: {exc}")
+
+    gain_spinbox.editingFinished.connect(set_gain_value)
+    sigs.append(gain_spinbox.editingFinished)
+
     return pvs, sigs
 
 

--- a/cam_types.py
+++ b/cam_types.py
@@ -106,9 +106,6 @@ class CamTypeScreenGenerator(QObject):
         )
         self.pvs_to_clean_up.append(self.model_pv)
 
-    def get_layout(self) -> QFormLayout:
-        return self.form
-
     def manuf_monitor(self, error: Exception | None) -> None:
         if error is None:
             self.manufacturer = self.manuf_pv.value

--- a/cam_types.py
+++ b/cam_types.py
@@ -69,7 +69,9 @@ class CamTypeScreenGenerator(QObject):
 
         # If we don't have PVs, stop here.
         if not base_pv:
-            self.full_name = "Generic"
+            self.full_name = "Disconnected"
+            start_button.setDisabled(True)
+            stop_button.setDisabled(True)
             return
 
         # If we have PVs, we can make the widgets work properly

--- a/cam_types.py
+++ b/cam_types.py
@@ -162,11 +162,13 @@ class CamTypeScreenGenerator(QObject):
     def cleanup(self) -> None:
         for pv in self.pvs_to_clean_up:
             pv.disconnect()
+        self.pvs_to_clean_up = []
         for sig in self.sigs_to_clean_up:
             try:
                 sig.disconnect()
             except TypeError:
                 ...
+        self.sigs_to_clean_up = []
         for _ in range(self.form.rowCount()):
             self.form.removeRow(0)
 

--- a/camviewer.ui
+++ b/camviewer.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>1106</width>
-    <height>1072</height>
+    <height>1129</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -772,6 +772,13 @@ Vmin\</string>
           </widget>
          </item>
         </layout>
+       </widget>
+      </item>
+      <item>
+       <widget class="QGroupBox" name="groupBoxControls">
+        <property name="title">
+         <string>Camera Controls</string>
+        </property>
        </widget>
       </item>
       <item>

--- a/camviewer_ui_impl.py
+++ b/camviewer_ui_impl.py
@@ -522,7 +522,7 @@ class GraphicUserInterface(QMainWindow):
         self.refresh_timeout_display_timer.setInterval(1000 * 20)
         self.refresh_timeout_display_timer.start()
 
-        self.model_screen_generator = None
+        self.cam_type_screen_generator = None
         self.setup_model_specific()
 
         self.ui.average.returnPressed.connect(self.onAverageSet)
@@ -672,8 +672,8 @@ class GraphicUserInterface(QMainWindow):
         self.end_monitors()
         if self.cameraBase != "":
             self.activeClear()
-        if self.model_screen_generator is not None:
-            self.model_screen_generator.cleanup()
+        if self.cam_type_screen_generator is not None:
+            self.cam_type_screen_generator.cleanup()
         if self.haveforce and self.forcedialog is not None:
             self.forcedialog.close()
         self.advdialog.close()
@@ -1138,8 +1138,8 @@ class GraphicUserInterface(QMainWindow):
                 pv.disconnect()
             except Exception:
                 pass
-        if self.model_screen_generator is not None:
-            self.model_screen_generator.cleanup()
+        if self.cam_type_screen_generator is not None:
+            self.cam_type_screen_generator.cleanup()
         self.otherpvs = []
 
     def shutdown(self):
@@ -2038,16 +2038,16 @@ class GraphicUserInterface(QMainWindow):
         self.getConfig()
 
     def setup_model_specific(self):
-        if self.model_screen_generator is None:
+        if self.cam_type_screen_generator is None:
             form = QFormLayout()
             self.ui.groupBoxControls.setLayout(form)
         else:
-            self.model_screen_generator.cleanup()
+            self.cam_type_screen_generator.cleanup()
             form = self.ui.groupBoxControls.layout()
-        self.model_screen_generator = CamTypeScreenGenerator(self.ctrlBase, form)
-        self.model_screen_generator.final_name.connect(self.new_model_name)
-        if self.model_screen_generator.full_name:
-            self.new_model_name(self.model_screen_generator.full_name)
+        self.cam_type_screen_generator = CamTypeScreenGenerator(self.ctrlBase, form)
+        self.cam_type_screen_generator.final_name.connect(self.new_model_name)
+        if self.cam_type_screen_generator.full_name:
+            self.new_model_name(self.cam_type_screen_generator.full_name)
 
     def new_model_name(self, name: str):
         self.ui.groupBoxControls.setTitle(f"{name} Controls")

--- a/camviewer_ui_impl.py
+++ b/camviewer_ui_impl.py
@@ -1138,9 +1138,10 @@ class GraphicUserInterface(QMainWindow):
                 pv.disconnect()
             except Exception:
                 pass
-        if self.cam_type_screen_generator is not None:
-            self.cam_type_screen_generator.cleanup()
         self.otherpvs = []
+        self.cameraBase = ""
+        self.ctrlBase = ""
+        self.setup_model_specific()
 
     def shutdown(self):
         self.clear()

--- a/camviewer_ui_impl.py
+++ b/camviewer_ui_impl.py
@@ -1138,6 +1138,8 @@ class GraphicUserInterface(QMainWindow):
                 pv.disconnect()
             except Exception:
                 pass
+        if self.model_screen_generator is not None:
+            self.model_screen_generator.cleanup()
         self.otherpvs = []
 
     def shutdown(self):

--- a/camviewer_ui_impl.py
+++ b/camviewer_ui_impl.py
@@ -15,7 +15,7 @@ from dialogs import advdialog
 from dialogs import markerdialog
 from dialogs import specificdialog
 from dialogs import forcedialog
-from models import ModelScreenGenerator
+from cam_types import CamTypeScreenGenerator
 
 import sys
 import os
@@ -2042,7 +2042,7 @@ class GraphicUserInterface(QMainWindow):
         else:
             self.model_screen_generator.cleanup()
             form = self.ui.groupBoxControls.layout()
-        self.model_screen_generator = ModelScreenGenerator(self.ctrlBase, form)
+        self.model_screen_generator = CamTypeScreenGenerator(self.ctrlBase, form)
         self.model_screen_generator.final_name.connect(self.new_model_name)
         if self.model_screen_generator.full_name:
             self.new_model_name(self.model_screen_generator.full_name)

--- a/camviewer_ui_impl.py
+++ b/camviewer_ui_impl.py
@@ -672,6 +672,8 @@ class GraphicUserInterface(QMainWindow):
         self.end_monitors()
         if self.cameraBase != "":
             self.activeClear()
+        if self.model_screen_generator is not None:
+            self.model_screen_generator.cleanup()
         if self.haveforce and self.forcedialog is not None:
             self.forcedialog.close()
         self.advdialog.close()

--- a/models.py
+++ b/models.py
@@ -1,0 +1,171 @@
+"""
+Brief model-specific screens to display below the main controls.
+
+This is to be used when there are important model-specific controls
+that are vital to the operation of the camera.
+
+These are limited to simple form layouts that will be included
+inside of a stock QGroupBox in the main screen.
+"""
+from __future__ import annotations
+
+from functools import partial
+
+from psp.Pv import Pv
+from PyQt5.QtCore import QObject, pyqtSignal
+from PyQt5.QtWidgets import QFormLayout, QLabel, QPushButton, QHBoxLayout, QSpinBox
+
+
+# groupBoxControls
+
+
+class ModelScreenGenerator(QObject):
+    """
+    This class creates a cam-specific QFormLayout to include in the main screen.
+
+    The layout will include basic start/stop camera controls for all models
+    and additional special controls that have been requested for specific models.
+    """
+
+    # GUI needs this to update the QGroupBox with the full model name
+    final_name = pyqtSignal(str)
+    manuf_ready = pyqtSignal()
+    model_ready = pyqtSignal()
+
+    def __init__(self, base_pv: str):
+        self.form = QFormLayout()
+        self.base_pv = base_pv
+        self.manufacturer = ""
+        self.model = ""
+        self.pvs: list[Pv] = []
+
+        # Put in the form elements that always should be there
+        self.acq_label = QLabel("Disconnected")
+        start_button = QPushButton("Start")
+        stop_button = QPushButton("Stop")
+        acq_layout = QHBoxLayout()
+        acq_layout.addWidget(self.acq_label)
+        acq_layout.addWidget(start_button)
+        acq_layout.addWidget(stop_button)
+        self.form.addRow("Acquire", acq_layout)
+
+        # If we don't have PVs, stop here.
+        # This is used to display something before we select a camera.
+        if not base_pv:
+            self.final_name.emit("Disconnected")
+            return
+
+        # If we have PVs, we can make the widgets work properly
+        self.manuf_ready.connect(self.finish_form)
+        self.model_ready.connect(self.finish_form)
+        self.acq_status_pv = Pv(
+            f"{base_pv}:Acquire_RBV",
+            monitor=self.new_acq_value,
+            initialize=True,
+        )
+        self.pvs.append(self.acq_status_pv)
+        self.acq_set_pv = Pv(f"{base_pv}:Acquire")
+        self.acq_set_pv.connect()
+        self.pvs.append(self.acq_set_pv)
+        start_button.clicked.connect(partial(self.set_acq_value, 1))
+        stop_button.clicked.connect(partial(self.set_acq_value, 0))
+
+        # Create a callback to finish the form later, given the model
+        self.manuf_pv = Pv(f"{base_pv}:Manufacturer_RBV")
+        self.pvs.append(self.manuf_pv)
+        self.manuf_cid = self.manuf_pv.add_connection_callback(self.manuf_ready)
+        self.manuf_pv.connect()
+        self.model_pv = Pv(f"{base_pv}:Model_RBV")
+        self.pvs.append(self.model_pv)
+        self.model_cid = self.model_pv.add_connection_callback(self.model_ready)
+        self.model_pv.connect()
+
+    def get_layout(self) -> QFormLayout:
+        return self.form
+
+    def manuf_read(self, is_connected: bool) -> None:
+        if is_connected:
+            self.manuf_pv.del_connection_callback(self.manuf_cid)
+            self.manufacturer = self.manuf_pv.value
+            self.manuf_pv.disconnect()
+            self.manuf_ready.emit()
+
+    def model_read(self, is_connected: bool) -> None:
+        if is_connected:
+            self.model_pv.del_connection_callback(self.model_cid)
+            self.model = self.model_pv.value
+            self.model_pv.disconnect()
+            self.model_ready.emit()
+
+    def finish_form(self) -> QFormLayout:
+        if not self.manufacturer or not self.model:
+            return
+        full_name = f"{self.manufacturer} {self.model}"
+        self.final_name.emit(full_name)
+        try:
+            finisher = form_finishers[full_name]
+        except KeyError:
+            print(f"Using basic controls for {full_name}")
+            return
+        else:
+            print(f"Loading special screen for {full_name}")
+        self.pvs.extend(finisher(self.form, self.base_pv))
+
+    def new_acq_value(self, error: Exception | None) -> None:
+        if error is None:
+            self.acq_label.setText(self.acq_status_pv.value)
+
+    def set_acq_value(self, value: int) -> None:
+        try:
+            self.acq_set_pv.put(value)
+        except Exception:
+            ...
+
+    def cleanup(self) -> None:
+        for pv in self.pvs:
+            pv.disconnect()
+
+
+def em_gain_andor(form: QFormLayout, base_pv: str) -> list[Pv]:
+    """
+    Update the basic form layout to include the andor em gain.
+    Return the list of Pvs so we can clean up later.
+    """
+    pvs = []
+
+    gain_label = QLabel()
+
+    def update_gain_label(error: Exception | None):
+        if error is None:
+            gain_label.setText(str(gain_rbv_pv.value))
+
+    gain_rbv_pv = Pv(
+        f"{base_pv}:AndorEMGain_RBV",
+        monitor=update_gain_label,
+        initialize=True,
+    )
+    pvs.append(gain_rbv_pv)
+
+    gain_set_pv = Pv(f"{base_pv}:AndorEMGain")
+    pvs.append(gain_set_pv)
+    gain_set_pv.connect()
+
+    def set_gain_value(value: int):
+        try:
+            gain_set_pv.put(value)
+        except Exception:
+            ...
+
+    gain_spinbox = QSpinBox()
+    gain_spinbox.valueChanged.connect(set_gain_value)
+
+    gain_layout = QHBoxLayout()
+    gain_layout.addWidget(gain_label)
+    gain_layout.addWidget(gain_spinbox)
+    form.addRow("EM Gain", gain_layout)
+    return pvs
+
+
+form_finishers = {
+    "Andor DU888_BV": em_gain_andor,
+}

--- a/models.py
+++ b/models.py
@@ -157,7 +157,7 @@ class ModelScreenGenerator(QObject):
             self.form.removeRow(0)
 
 
-def em_gain_andor(form: QFormLayout, base_pv: str) -> list[Pv]:
+def em_gain_andor(form: QFormLayout, base_pv: str) -> tuple[list[Pv], list[pyqtSignal]]:
     """
     Update the basic form layout to include the andor em gain.
     Return the list of Pvs so we can clean up later.
@@ -182,15 +182,16 @@ def em_gain_andor(form: QFormLayout, base_pv: str) -> list[Pv]:
     pvs.append(gain_set_pv)
     gain_set_pv.connect()
 
-    def set_gain_value(value: int):
+    def set_gain_value():
         try:
-            gain_set_pv.put(value)
+            gain_set_pv.put(gain_spinbox.value())
         except Exception:
             ...
 
     gain_spinbox = QSpinBox()
-    gain_spinbox.valueChanged.connect(set_gain_value)
-    sigs.append(gain_spinbox.valueChanged)
+    gain_spinbox.setMaximum(10000000)
+    gain_spinbox.editingFinished.connect(set_gain_value)
+    sigs.append(gain_spinbox.editingFinished)
 
     gain_layout = QHBoxLayout()
     gain_layout.addWidget(gain_label)


### PR DESCRIPTION
Request from UED
Awaiting feedback in https://jira.slac.stanford.edu/browse/ECS-7005 but I think the code is done now.

The main idea here is that UED wanted camera-specific controls for their Andor cameras because they need to change the gain a lot and using two GUIs is burdensome to operations.

Every cam will get a camera controls section on the main screen with at least start/stop controls, and specific camera models can be granted extra behavior.

This is implemented by adding an additional empty QGroupBox, giving it a QFormLayout, and repeatedly emptying and filling this layout as needed when cameras swap around.

I implemented this in a submodule and had it clean itself up on camera switches instead of trying to weave it into the big camviewer file. I didn't use any ui files because I wanted to keep this simple and limited.

![image](https://github.com/user-attachments/assets/c2327049-5fec-46bf-9d57-7c98f8f7073e)
