### PR TITLE
FIX: wrong image size handling

### DIFF
--- a/camviewer_ui_impl.py
+++ b/camviewer_ui_impl.py
@@ -2026,6 +2026,24 @@ class GraphicUserInterface(QMainWindow):
         # Get camera configuration
         self.getConfig()
 
+        # Check the expected size against the count to generate warnings
+        first_image_count = len(self.camera.value)
+        expected_count = self.rowPv.value * self.colPv.value
+        if self.isColor:
+            expected_count *= 3
+        if first_image_count != expected_count:
+            QMessageBox.warning(
+                None,
+                "Warning",
+                (
+                    "IOC misconfiguration likely!\n"
+                    f"Received {first_image_count} pixels, expected {expected_count} "
+                    f"for {self.rowPv.value} x {self.colPv.value}."
+                ),
+                QMessageBox.Ok,
+                QMessageBox.Ok,
+            )
+
     def normalize_selectors(self):
         """
         Update the visual appearance of the camera combobox and the menu to be correct.

--- a/pycaqtimage/pycaqtimage.sip
+++ b/pycaqtimage/pycaqtimage.sip
@@ -413,8 +413,12 @@ static void _pyColorImagePvCallback(void* cadata, long count, size_t size, void*
                        colIncK[orientation];
     int iNewAverage  = imageBuffer->iNumAveraged + 1;
 
-    UNUSED(count);
     UNUSED(size);
+
+    if (count != imageBuffer->size * 3) {
+        // Wrong data size, unsafe to continue
+        return;
+    }
 
     /* If we're using the color image, don't average, just copy and we're done! */
     if (!imageBuffer->useGray) {
@@ -460,7 +464,11 @@ static void _pyImagePvCallback(void* cadata, long count, size_t size, void* usr)
 {
   ImageBuffer*  imageBuffer = reinterpret_cast<ImageBuffer*>(usr);
 
-  UNUSED(count);
+  if (count != imageBuffer->size) {
+    // Wrong data size, unsafe to continue
+    return;
+  }
+
   switch (size) {
     case 4:
 	_pyDoAvg(imageBuffer, reinterpret_cast<uint32_t*>(cadata));


### PR DESCRIPTION
Alternative to #22 

I think this is the simplest possible variant to avoid the crash.
Simply compare the count to the size (which is set as width*height). If they are not the same, warn the user and do not process any image data.

In practice, this only affects us when the IOC is misconfigured. Otherwise the data will always match and we will get good frames.

If the camera is misconfigured, this PR will result in:
- A warning
- A completely black (pixel values =  0) image