### PR TITLE
FIX: actually clear the image when we load an invalid cam

### DIFF
--- a/camviewer_ui_impl.py
+++ b/camviewer_ui_impl.py
@@ -2051,7 +2051,7 @@ class GraphicUserInterface(QMainWindow):
         ):
             # Clear the image so that we don't have a stale image from the previous cam
             self.ui.display_image.image.fill(0)
-            self.after_new_min_or_max_pixel()
+            self.ui.display_image.repaint()
             # Report which issue we had
             if self.rowPv is None or self.colPv is None:
                 self.ui.label_status.setText("IOC timeout in setup")

--- a/camviewer_ui_impl.py
+++ b/camviewer_ui_impl.py
@@ -464,6 +464,7 @@ class GraphicUserInterface(QMainWindow):
         )
         self.ui.pushbutton_auto_range.pressed.connect(self.set_auto_range)
         self.ui.checkbox_auto_range.stateChanged.connect(self.set_auto_range)
+        self.set_color_scaling_enabled(False)
 
         self.ui.horizontalSliderLens.sliderReleased.connect(self.onSliderLensReleased)
         self.ui.horizontalSliderLens.valueChanged.connect(self.onSliderLensChanged)
@@ -471,6 +472,7 @@ class GraphicUserInterface(QMainWindow):
 
         self.ui.singleframe.toggled.connect(self.onCheckDisplayUpdate)
         self.ui.grayScale.stateChanged.connect(self.onCheckGrayUpdate)
+        self.ui.grayScale.setVisible(False)
         self.ui.local_avg.toggled.connect(self.onCheckDisplayUpdate)
 
         self.ui.comboBoxColor.currentIndexChanged.connect(
@@ -968,6 +970,8 @@ class GraphicUserInterface(QMainWindow):
 
     def onCheckGrayUpdate(self, newval):
         pycaqtimage.pySetImageBufferGray(self.imageBuffer, newval)
+        if self.isColor:
+            self.set_color_scaling_enabled(newval)
         if self.cfg is None:
             self.dumpConfig()
 
@@ -1947,6 +1951,7 @@ class GraphicUserInterface(QMainWindow):
     def connectCamera(self, sCameraPv, index, sNotifyPv=None):
         self.selected_cam_ready = False
         self.ui.label_status.setText("Cleaning up...")
+        self.set_color_scaling_enabled(False)
         self.camera = self.disconnectPv(self.camera)
         self.notify = self.disconnectPv(self.notify)
         self.nordPv = self.disconnectPv(self.nordPv)
@@ -2071,11 +2076,13 @@ class GraphicUserInterface(QMainWindow):
             self.camera.processor = pycaqtimage.pyCreateColorImagePvCallbackFunc(
                 self.imageBuffer
             )
+            self.set_color_scaling_enabled(self.ui.grayScale.isChecked())
             self.ui.grayScale.setVisible(True)
         else:
             self.camera.processor = pycaqtimage.pyCreateImagePvCallbackFunc(
                 self.imageBuffer
             )
+            self.set_color_scaling_enabled(True)
             self.ui.grayScale.setVisible(False)
         self.notify.add_monitor_callback(self.haveImageCallback)
         self.camera.getevt_cb = self.imagePvUpdateCallback
@@ -2684,6 +2691,28 @@ class GraphicUserInterface(QMainWindow):
             self.set_new_max_pixel(self.max_px)
             self.set_new_min_pixel(self.min_px)
             self.after_new_min_or_max_pixel()
+
+    def set_color_scaling_enabled(self, enabled: bool):
+        """
+        Set the color scaling to enabled or disabled.
+
+        This enables or disables all the color scaling widgets.
+        Color scaling is only functional when there is a
+        properly configured camera in b/w mode.
+
+        If disabling, we also uncheck the auto range checkbox
+        to prevent auto scaling on garbage data.
+        """
+        self.ui.comboBoxColor.setEnabled(enabled)
+        self.ui.comboBoxScale.setEnabled(enabled)
+        self.ui.horizontalSliderRangeMin.setEnabled(enabled)
+        self.ui.horizontalSliderRangeMax.setEnabled(enabled)
+        self.ui.spinbox_range_min.setEnabled(enabled)
+        self.ui.spinbox_range_max.setEnabled(enabled)
+        self.ui.checkbox_auto_range.setEnabled(enabled)
+        self.ui.pushbutton_auto_range.setEnabled(enabled)
+        if not enabled:
+            self.ui.checkbox_auto_range.setChecked(False)
 
     def onLensEnter(self):
         try:


### PR DESCRIPTION
A follow-up to #31 to fix how we need to clear the live image when we select a cam that nominally connects but doesn't have any pixel values in the image (and therefore, nothing to render).

In these cases we want to clear the image so it's clear that we aren't still looking at the previous camera.

This is how I originally had it (working), but then I decided to try it another way, and both seemed to work, so I went along with the second variant, but my new way never actually worked at all and it was just NFS propagation being slow that fooled me into thinking both ways were equivalent. I had unknowingly only tested it with this variant.

Tested via running in xcs, picking a working cam, and then switching to e.g. xcs_gige_3
```
./run_viewer_local.sh --instrument xcs --pvlist /cds/group/pcds/pyps/config/xcs/camviewer.cfg
```