### PR TITLE
FIX: right side font sizing

### DIFF
--- a/camviewer.ui
+++ b/camviewer.ui
@@ -167,7 +167,7 @@
     <item row="0" column="2" rowspan="3">
      <widget class="QScrollArea" name="rightScrollArea">
       <property name="sizePolicy">
-       <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+       <sizepolicy hsizetype="Fixed" vsizetype="Expanding">
         <horstretch>0</horstretch>
         <verstretch>0</verstretch>
        </sizepolicy>
@@ -197,7 +197,7 @@
        <enum>Qt::ScrollBarAlwaysOff</enum>
       </property>
       <property name="sizeAdjustPolicy">
-       <enum>QAbstractScrollArea::AdjustToContents</enum>
+       <enum>QAbstractScrollArea::AdjustIgnored</enum>
       </property>
       <property name="widgetResizable">
        <bool>true</bool>
@@ -234,7 +234,7 @@
        </property>
        <layout class="QVBoxLayout" name="RightPanel">
         <property name="sizeConstraint">
-         <enum>QLayout::SetFixedSize</enum>
+         <enum>QLayout::SetDefaultConstraint</enum>
         </property>
         <property name="leftMargin">
          <number>0</number>
@@ -251,20 +251,20 @@
         <item>
          <widget class="QGroupBox" name="groupBoxCamera">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
           <property name="minimumSize">
            <size>
-            <width>300</width>
+            <width>0</width>
             <height>0</height>
            </size>
           </property>
           <property name="maximumSize">
            <size>
-            <width>300</width>
+            <width>16777215</width>
             <height>16777215</height>
            </size>
           </property>
@@ -568,20 +568,20 @@
         <item>
          <widget class="QGroupBox" name="groupBoxControls">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
           <property name="minimumSize">
            <size>
-            <width>300</width>
+            <width>0</width>
             <height>0</height>
            </size>
           </property>
           <property name="maximumSize">
            <size>
-            <width>300</width>
+            <width>16777215</width>
             <height>16777215</height>
            </size>
           </property>
@@ -593,20 +593,20 @@
         <item>
          <widget class="QGroupBox" name="groupBoxColor">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
           <property name="minimumSize">
            <size>
-            <width>300</width>
+            <width>0</width>
             <height>0</height>
            </size>
           </property>
           <property name="maximumSize">
            <size>
-            <width>300</width>
+            <width>16777215</width>
             <height>16777215</height>
            </size>
           </property>
@@ -793,20 +793,20 @@
         <item>
          <widget class="QGroupBox" name="groupBoxAverage">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
           <property name="minimumSize">
            <size>
-            <width>300</width>
+            <width>0</width>
             <height>0</height>
            </size>
           </property>
           <property name="maximumSize">
            <size>
-            <width>300</width>
+            <width>16777215</width>
             <height>16777215</height>
            </size>
           </property>
@@ -853,20 +853,20 @@
         <item>
          <widget class="QGroupBox" name="groupBoxMarker">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
           <property name="minimumSize">
            <size>
-            <width>300</width>
+            <width>0</width>
             <height>0</height>
            </size>
           </property>
           <property name="maximumSize">
            <size>
-            <width>300</width>
+            <width>16777215</width>
             <height>16777215</height>
            </size>
           </property>
@@ -1365,20 +1365,20 @@
         <item>
          <widget class="QGroupBox" name="groupBoxROI">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
           <property name="minimumSize">
            <size>
-            <width>300</width>
+            <width>0</width>
             <height>0</height>
            </size>
           </property>
           <property name="maximumSize">
            <size>
-            <width>300</width>
+            <width>16777215</width>
             <height>16777215</height>
            </size>
           </property>
@@ -1594,20 +1594,20 @@
         <item>
          <widget class="QGroupBox" name="groupBoxZoom">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
           <property name="minimumSize">
            <size>
-            <width>300</width>
+            <width>0</width>
             <height>0</height>
            </size>
           </property>
           <property name="maximumSize">
            <size>
-            <width>300</width>
+            <width>16777215</width>
             <height>16777215</height>
            </size>
           </property>
@@ -1676,21 +1676,21 @@
            <bool>true</bool>
           </property>
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
           <property name="minimumSize">
            <size>
-            <width>300</width>
-            <height>120</height>
+            <width>0</width>
+            <height>0</height>
            </size>
           </property>
           <property name="maximumSize">
            <size>
-            <width>300</width>
-            <height>120</height>
+            <width>16777215</width>
+            <height>16777215</height>
            </size>
           </property>
           <property name="title">
@@ -1806,20 +1806,20 @@
         <item>
          <widget class="QGroupBox" name="groupBoxExpert">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
           </property>
           <property name="minimumSize">
            <size>
-            <width>300</width>
+            <width>0</width>
             <height>0</height>
            </size>
           </property>
           <property name="maximumSize">
            <size>
-            <width>300</width>
+            <width>16777215</width>
             <height>16777215</height>
            </size>
           </property>

--- a/camviewer_ui_impl.py
+++ b/camviewer_ui_impl.py
@@ -50,6 +50,7 @@ from PyQt5.QtGui import (
     QPixmap,
     QDrag,
     QImageWriter,
+    QFontMetricsF,
 )
 from PyQt5.QtCore import (
     QTimer,
@@ -692,6 +693,16 @@ class GraphicUserInterface(QMainWindow):
             self.onCameraSelect(int(cameraIndex))
         except Exception:
             pass
+
+        # Set the right hand area's width based on font sizes
+        font = self.ui.labelCamera.font()
+        fm = QFontMetricsF(font)
+        charwidth = fm.averageCharWidth()
+        # We want to make it wide enough for 50 average chars
+        width = 50 * charwidth
+        self.ui.rightScrollArea.setFixedWidth(width)
+        self.ui.rightPanelWidget.setFixedWidth(width)
+
         self.efilter = FilterObject(self.app, self)
         self.scroll_size_filter = ScrollSizeFilter(self)
 


### PR DESCRIPTION
Somewhat experimental: dynamically adjust the size of the right hand area based on the apparent rendered font size. I set the width to be about 50 characters because this matches my locally observed size that I've been designing on.

The goal is for people running on different laptops which normally have their text get cut off to have more normal sizing behavior.

I have no idea if this actually works. I'll need to try it on a few different monitors. I'll need to bug Patrick too. Something for next week.

Incidentally:
- Changed all the group boxes from fixed to preferred sizing so they can resize to fill the scroll widget. This means I don't have to have the resize logic manually resize every single widget at startup.
- Fixed a scroll resizing race condition that stemmed from installing the event filter too early.

Alternatives explored:
- Using a splitter was tried, but it was too terrible to implement without exploding the layout in the camviewer.ui file
- Setting the widget widths to be something other than "fixed" caused the group boxes to explode out the right size of the window...