### PR TITLE
ENH: rework global marker handling

### DIFF
--- a/DisplayImage.py
+++ b/DisplayImage.py
@@ -458,20 +458,63 @@ class DisplayImage(QWidget):
             self.gui.dumpConfig()
 
     def set_one_marker(self, index: int, marker: param.Point):
+        """
+        Replace any of the marker cross locations with a new Point object.
+
+        This allows us to swap marker locations in and out as necessary in
+        other parts of the application.
+
+        The Point object can be retained by the caller and its coordinates
+        can be changed to update the marker position here.
+
+        Parameters
+        ----------
+        index : int
+            Whether to replace marker 0, 1, 2, or 3
+            which correspond to markers 1, 2, 3, and 4 on the GUI.
+        marker : Point
+            An object that stores the x, y location of the associated marker.
+        """
         self.lMarker[index] = marker
 
     def set_markers(self, markers: list[param.Point]):
+        """
+        Replace all of the marker cross locations with a list of Point objects.
+
+        This is a shortcut for calling set_one_marker four times on each of the
+        valid marker indices.
+
+        Parameters
+        ----------
+        markers: list of Point
+            A list of 4 objects that store the x, y locations of their
+            associated markers.
+        """
         for index in range(4):
             self.set_one_marker(index, markers[index])
 
 
 def default_markers() -> list[param.Point]:
+    """
+    Return a list of 4 Points that represent the default marker positions.
+
+    The default marker positions are 100 points horizontally and 100 points
+    vertically away from each of the corners of the image, not on the image
+    itself but off of it.
+    """
     pts = [param.Point(0, 0), param.Point(0, 0), param.Point(0, 0), param.Point(0, 0)]
     reset_markers(pts)
     return pts
 
 
 def reset_markers(markers: list[param.Point]) -> None:
+    """
+    Given a list of 4 Points that represent marker positions, reset them to the defaults.
+
+    The default marker positions are 100 points horizontally and 100 points
+    vertically away from each of the corners of the image, not on the image
+    itself but off of it.
+    """
     markers[0].setAbs(-100, 100)
     markers[1].setAbs(param.x + 100, -100)
     markers[2].setAbs(param.x + 100, param.y + 100)

--- a/DisplayImage.py
+++ b/DisplayImage.py
@@ -457,8 +457,12 @@ class DisplayImage(QWidget):
         if self.gui.cfg is None:
             self.gui.dumpConfig()
 
+    def set_one_marker(self, index: int, marker: param.Point):
+        self.lMarker[index] = marker
+
     def set_markers(self, markers: list[param.Point]):
-        self.lMarker = markers
+        for index in range(4):
+            self.set_one_marker(index, markers[index])
 
 
 def default_markers() -> list[param.Point]:

--- a/DisplayImage.py
+++ b/DisplayImage.py
@@ -515,7 +515,7 @@ def reset_markers(markers: list[param.Point]) -> None:
     vertically away from each of the corners of the image, not on the image
     itself but off of it.
     """
-    markers[0].setAbs(-100, 100)
+    markers[0].setAbs(-100, -100)
     markers[1].setAbs(param.x + 100, -100)
     markers[2].setAbs(param.x + 100, param.y + 100)
     markers[3].setAbs(-100, param.y + 100)

--- a/DisplayImage.py
+++ b/DisplayImage.py
@@ -33,12 +33,7 @@ class DisplayImage(QWidget):
         self.sWindowTitle = "Camera: None"
 
         # set marker data
-        self.lMarker = [
-            param.Point(-100, -100),  # image
-            param.Point(param.x + 100, -100),
-            param.Point(param.x + 100, param.y + 100),
-            param.Point(-100, param.y + 100),
-        ]
+        self.lMarker = default_markers()
         self.lPenColor = [
             (0 / 255.0, 128 / 255.0, 255 / 255.0),  # matplotlib colors!!
             (255 / 255.0, 0 / 255.0, 0 / 255.0),
@@ -118,12 +113,7 @@ class DisplayImage(QWidget):
         self.gui.updateRoiText()
         self.gui.updateMiscInfo()
         if reset:
-            self.lMarker = [
-                param.Point(-100, -100),  # image
-                param.Point(param.x + 100, -100),
-                param.Point(param.x + 100, param.y + 100),
-                param.Point(-100, param.y + 100),
-            ]
+            reset_markers(self.lMarker)
 
     def pWidth(self):
         if param.orientation & 2:
@@ -466,3 +456,19 @@ class DisplayImage(QWidget):
         self.update()
         if self.gui.cfg is None:
             self.gui.dumpConfig()
+
+    def set_markers(self, markers: list[param.Point]):
+        self.lMarker = markers
+
+
+def default_markers() -> list[param.Point]:
+    pts = [param.Point(0, 0), param.Point(0, 0), param.Point(0, 0), param.Point(0, 0)]
+    reset_markers(pts)
+    return pts
+
+
+def reset_markers(markers: list[param.Point]) -> None:
+    markers[0].setAbs(-100, 100)
+    markers[1].setAbs(param.x + 100, -100)
+    markers[2].setAbs(param.x + 100, param.y + 100)
+    markers[3].setAbs(-100, param.y + 100)

--- a/camviewer.ui
+++ b/camviewer.ui
@@ -2702,7 +2702,7 @@ Vmin\</string>
   </action>
   <action name="actionResetMarkers">
    <property name="text">
-    <string>Reset All Markers</string>
+    <string>Reset Local Markers</string>
    </property>
   </action>
   <action name="actionMS">

--- a/camviewer.ui
+++ b/camviewer.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1222</width>
-    <height>1197</height>
+    <width>1242</width>
+    <height>1255</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -211,7 +211,7 @@
          <x>0</x>
          <y>0</y>
          <width>300</width>
-         <height>1155</height>
+         <height>1213</height>
         </rect>
        </property>
        <property name="sizePolicy">
@@ -875,6 +875,36 @@
           </property>
           <layout class="QVBoxLayout" name="horizontalLayoutMarker">
            <item>
+            <layout class="QHBoxLayout" name="horizontalLayout_2">
+             <property name="leftMargin">
+              <number>36</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>16</number>
+             </property>
+             <item>
+              <widget class="QRadioButton" name="global_button">
+               <property name="text">
+                <string>Global</string>
+               </property>
+               <property name="checked">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QRadioButton" name="local_button">
+               <property name="text">
+                <string>Local</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item>
             <layout class="QHBoxLayout" name="horizontalLayout_Marker1">
              <item>
               <widget class="QPushButton" name="pushButtonMarker1">
@@ -1000,6 +1030,19 @@
                </item>
               </layout>
              </item>
+             <item>
+              <widget class="QLabel" name="cross1_status">
+               <property name="font">
+                <font>
+                 <family>Monospace</family>
+                 <pointsize>12</pointsize>
+                </font>
+               </property>
+               <property name="text">
+                <string>L</string>
+               </property>
+              </widget>
+             </item>
             </layout>
            </item>
            <item>
@@ -1118,6 +1161,19 @@
                 </widget>
                </item>
               </layout>
+             </item>
+             <item>
+              <widget class="QLabel" name="cross2_status">
+               <property name="font">
+                <font>
+                 <family>Monospace</family>
+                 <pointsize>12</pointsize>
+                </font>
+               </property>
+               <property name="text">
+                <string>L</string>
+               </property>
+              </widget>
              </item>
             </layout>
            </item>
@@ -1238,6 +1294,19 @@
                </item>
               </layout>
              </item>
+             <item>
+              <widget class="QLabel" name="cross3_status">
+               <property name="font">
+                <font>
+                 <family>Monospace</family>
+                 <pointsize>12</pointsize>
+                </font>
+               </property>
+               <property name="text">
+                <string>L</string>
+               </property>
+              </widget>
+             </item>
             </layout>
            </item>
            <item>
@@ -1356,6 +1425,19 @@
                 </widget>
                </item>
               </layout>
+             </item>
+             <item>
+              <widget class="QLabel" name="cross4_status">
+               <property name="font">
+                <font>
+                 <family>Monospace</family>
+                 <pointsize>12</pointsize>
+                </font>
+               </property>
+               <property name="text">
+                <string>L</string>
+               </property>
+              </widget>
              </item>
             </layout>
            </item>
@@ -2384,7 +2466,7 @@ Vmin\</string>
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>1222</width>
+     <width>1242</width>
      <height>20</height>
     </rect>
    </property>

--- a/camviewer_ui_impl.py
+++ b/camviewer_ui_impl.py
@@ -887,14 +887,39 @@ class GraphicUserInterface(QMainWindow):
         self.ui.actionGlobalMarkers.setChecked(False)
         self.onGlobMarks()
 
-    def onGlobMarks(self, on_init=False):
-        """Apply global or local mode based on the UI state"""
+    def onGlobMarks(self, on_init: bool = False):
+        """
+        Apply global or local mode based on the UI state.
+
+        Parameters
+        ----------
+        on_init : bool
+            If False (the default) assume we're not initalizing a camera.
+            Therefore, we only need to take further action if the mode
+            is changing. Set this to True while initializing a camera
+            to ensure that the new camera's markers replace the
+            previous camera's markers.
+        """
         use_global = self.ui.actionGlobalMarkers.isChecked()
         self.ui.global_button.setChecked(use_global)
         self.ui.local_button.setChecked(not use_global)
         self.setUseGlobalMarkers(use_global, on_init=on_init)
 
-    def setUseGlobalMarkers(self, ugm, on_init=False):
+    def setUseGlobalMarkers(self, ugm: bool, on_init: bool =False):
+        """
+        Apply global or local mode.
+
+        Parameters
+        ----------
+        ugm: bool
+            True to apply global markers, False to apply local markers.
+        on_init : bool
+            If False (the default) assume we're not initalizing a camera.
+            Therefore, we only need to take further action if the mode
+            is changing. Set this to True while initializing a camera
+            to ensure that the new camera's markers replace the
+            previous camera's markers.        
+        """
         if ugm != self.useglobmarks or on_init:
             self.useglobmarks = ugm
             if ugm:

--- a/camviewer_ui_impl.py
+++ b/camviewer_ui_impl.py
@@ -957,8 +957,11 @@ class GraphicUserInterface(QMainWindow):
                     pt = self.ui.display_image.lMarker[i].abs()
                     newx = int(pt.x())
                     newy = int(pt.y())
-                    cross_x_pv = self.globmarkpvs[f"cross_{i+1}x"]
-                    cross_y_pv = self.globmarkpvs[f"cross_{i+1}y"]
+                    try:
+                        cross_x_pv = self.globmarkpvs[f"cross_{i+1}x"]
+                        cross_y_pv = self.globmarkpvs[f"cross_{i+1}y"]
+                    except KeyError:
+                        return
                     if cross_x_pv.isinitialized and cross_y_pv.isinitialized:
                         try:
                             cross_x_pv.put(newx)

--- a/camviewer_ui_impl.py
+++ b/camviewer_ui_impl.py
@@ -1903,6 +1903,7 @@ class GraphicUserInterface(QMainWindow):
         self.launch_edm_pv = self.disconnectPv(self.launch_edm_pv)
         self.launch_gui_script = ""
         self.launch_edm_script = ""
+        self.disconnectMarkerPVs()
         self.calibPVName = ""
         self.displayFormat = "%12.8g"
 

--- a/camviewer_ui_impl.py
+++ b/camviewer_ui_impl.py
@@ -2322,6 +2322,9 @@ class GraphicUserInterface(QMainWindow):
 
     def setupSpecific(self):
         self.ui.actionGlobalMarkers.setChecked(self.useglobmarks)
+        self.ui.global_button.setChecked(self.useglobmarks)
+        self.ui.local_button.setChecked(not self.useglobmarks)
+
         self.setupComboMonitor(
             ":TriggerMode_RBV", self.specificdialog.ui.cameramodeG, ":TriggerMode"
         )

--- a/camviewer_ui_impl.py
+++ b/camviewer_ui_impl.py
@@ -9,63 +9,53 @@
 #
 from __future__ import annotations
 
-from camviewer_ui import Ui_MainWindow
-from psp.Pv import Pv
-from dialogs import advdialog
-from dialogs import markerdialog
-from dialogs import specificdialog
-from dialogs import forcedialog
-from cam_types import CamTypeScreenGenerator
-from DisplayImage import default_markers, reset_markers
-
-import sys
-import os
-from pycaqtimage import pycaqtimage
-import pyca
-import math
-import re
-import time
+import contextlib
 import functools
+import math
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import typing
+
 import numpy as np
 import numpy.typing as npt
-import tempfile
-import shutil
-import typing
-import contextlib
-import subprocess
-
+import pyca
+from psp.Pv import Pv
+from PyQt5.QtCore import (
+    QEvent,
+    QMimeData,
+    QObject,
+    QPoint,
+    QSettings,
+    QSize,
+    Qt,
+    QTimer,
+    pyqtSignal,
+)
+from PyQt5.QtGui import QClipboard, QDrag, QFontMetricsF, QImageWriter, QPixmap
 from PyQt5.QtWidgets import (
-    QSizePolicy,
+    QAction,
+    QApplication,
+    QDialogButtonBox,
+    QFileDialog,
+    QFormLayout,
     QLabel,
     QMainWindow,
-    QSpacerItem,
-    QFileDialog,
     QMessageBox,
-    QAction,
-    QDialogButtonBox,
-    QApplication,
-    QFormLayout,
-)
-from PyQt5.QtGui import (
-    QClipboard,
-    QPixmap,
-    QDrag,
-    QImageWriter,
-    QFontMetricsF,
-)
-from PyQt5.QtCore import (
-    QTimer,
-    QPoint,
-    QSize,
-    QObject,
-    QEvent,
-    Qt,
-    QMimeData,
-    QSettings,
-    pyqtSignal,
+    QSizePolicy,
+    QSpacerItem,
 )
 
 import param
+from cam_types import CamTypeScreenGenerator
+from camviewer_ui import Ui_MainWindow
+from dialogs import advdialog, forcedialog, markerdialog, specificdialog
+from DisplayImage import default_markers, reset_markers
+from pycaqtimage import pycaqtimage
 
 
 #

--- a/camviewer_ui_impl.py
+++ b/camviewer_ui_impl.py
@@ -112,12 +112,6 @@ class cfginfo:
     def add(self, attr, val):
         self.dict[attr] = val
 
-    def get(self, attr, default):
-        try:
-            return self.dict[attr]
-        except KeyError:
-            return default
-
     def __getattr__(self, name):
         if name in self.dict.keys():
             return self.dict[name]

--- a/camviewer_ui_impl.py
+++ b/camviewer_ui_impl.py
@@ -908,10 +908,8 @@ class GraphicUserInterface(QMainWindow):
         if ugm != self.useglobmarks or on_init:
             self.useglobmarks = ugm
             if ugm:
-                self.ui.display_image.set_markers(self.global_marker_points)
                 self.connectMarkerPVs()
             else:
-                self.ui.display_image.set_markers(self.local_marker_points)
                 self.disconnectMarkerPVs()
             self.updateMarkerText(do_puts=False)
             if self.cfg is None:
@@ -1088,13 +1086,8 @@ class GraphicUserInterface(QMainWindow):
         self.ui.display_image.update()
 
     def onMarkerReset(self):
-        self.ui.display_image.lMarker = [
-            param.Point(-100, -100),
-            param.Point(param.x + 100, -100),
-            param.Point(param.x + 100, param.y + 100),
-            param.Point(-100, param.y + 100),
-        ]
-        self.updateMarkerText(True, True, 3, 15)
+        reset_markers(self.local_marker_points)
+        self.updateMarkerText(True, True, 3, 15, do_puts=False)
         self.updateall()
         if self.cfg is None:
             self.dumpConfig()
@@ -1834,13 +1827,17 @@ class GraphicUserInterface(QMainWindow):
         status_label = getattr(self.ui, f"cross{n + 1}_status")
         status_label.setText("G")
 
+        old_point = self.ui.display_image.lMarker[n]
+        new_point = self.global_marker_points[n]
+        self.ui.display_image.set_one_marker(n, new_point)
+
         newx = cross_x_pv.value
         newy = cross_y_pv.value
-        point = self.global_marker_points[n]
-        if point.x == newx and point.y == newy:
+        if old_point.x == newx and old_point.y == newy:
             return
 
-        point.setAbs(newx, newy)
+        new_point.setAbs(newx, newy)
+
         self.updateMarkerText(True, True, 0, 1 << n, do_puts=False)
         self.updateMarkerValue()
         self.updateall()
@@ -1886,6 +1883,7 @@ class GraphicUserInterface(QMainWindow):
         self.ui.cross2_status.setText("L")
         self.ui.cross3_status.setText("L")
         self.ui.cross4_status.setText("L")
+        self.ui.display_image.set_markers(self.local_marker_points)
         return False
 
     def setupDrags(self):


### PR DESCRIPTION
See https://jira.slac.stanford.edu/browse/ECS-7128 for the full motivation and context.

### Main Goals
- Make "global" marker mode use all four markers instead of only the first two markers.
- Allow seamless transitions between local and global marker modes.
- Make it really clear which markers are global and which are local via marking them with G or L.
- Completely separate the saved local marker positions from the global marker positions, so that neither set overrides the other.
- Allow for "partial" loading of global markers in the event that only some of the PVs exist.

#### Notable Internal Fixes / Adjustments
- Allow us to cleanly swap markers in and out in DisplayImage to help separate global and local marker position data in memory.
- Remove vestigial code for an older version that had weird special global 2 mode for markers 3, 4 with different behavior.
- Improve the performance of the global marker code by removing an unnecessary dumpConfig step, which suddenly was slowing down the GUI when I doubled the number of global markers.
- Rework the config loading code to remove strange code branches and give us consistent first-load behavior for new cameras.

![image](https://github.com/user-attachments/assets/f4446530-beeb-41fd-8f2d-fadf8c5cf8a6)
