### PR TITLE
ENH: remove nord and nelm and adjust accordingly

### DIFF
--- a/camviewer_ui_impl.py
+++ b/camviewer_ui_impl.py
@@ -2089,14 +2089,18 @@ class GraphicUserInterface(QMainWindow):
                 self.bits = 12
                 print("Bits PV did not connect or had bad value, using default 12")
 
-        # Ensure positive bit depth no bigger than 32
-        # Negative bit depth and very large bit depths both break the app
-        self.bits = min(max(1, self.bits), 32)
-        self.maxcolor = (1 << self.bits) - 1
+        # Ensure positive bit depth no bigger than 16
+        # Negative bit depth and large bit depths both break the app
+        self.bits = min(max(1, self.bits), 16)
+        self.maxcolor = 2**self.bits - 1
+        if self.isColor:
+            self.maxcolor *= 3
+            self.maxcolor = min(self.maxcolor, 2**16 - 1)
+
         self.ui.horizontalSliderRangeMin.setMaximum(self.maxcolor)
-        self.ui.horizontalSliderRangeMin.setTickInterval((1 << self.bits) / 4)
+        self.ui.horizontalSliderRangeMin.setTickInterval(self.maxcolor // 4)
         self.ui.horizontalSliderRangeMax.setMaximum(self.maxcolor)
-        self.ui.horizontalSliderRangeMax.setTickInterval((1 << self.bits) / 4)
+        self.ui.horizontalSliderRangeMax.setTickInterval(self.maxcolor // 4)
         self.ui.spinbox_range_max.setMaximum(self.maxcolor)
         self.ui.spinbox_range_min.setMaximum(self.maxcolor)
 

--- a/camviewer_ui_impl.py
+++ b/camviewer_ui_impl.py
@@ -2042,23 +2042,6 @@ class GraphicUserInterface(QMainWindow):
             self.disconnectPv(size2)
             self.isColor = False
 
-        if self.lFlags[index] != "":
-            self.bits = int(self.lFlags[index])
-        else:
-            self.bits_pv = self.connectPv(self.cameraBase + ":BitsPerPixel_RBV")
-            if self.bits_pv is None:
-                self.ui.label_status.setText("IOC timeout in setup")
-                print("IOC timeout in setup (bits per pixel PV)")
-                return
-            self.bits = self.bits_pv.value
-        self.maxcolor = (1 << self.bits) - 1
-        self.ui.horizontalSliderRangeMin.setMaximum(self.maxcolor)
-        self.ui.horizontalSliderRangeMin.setTickInterval((1 << self.bits) / 4)
-        self.ui.horizontalSliderRangeMax.setMaximum(self.maxcolor)
-        self.ui.horizontalSliderRangeMax.setTickInterval((1 << self.bits) / 4)
-        self.ui.spinbox_range_max.setMaximum(self.maxcolor)
-        self.ui.spinbox_range_min.setMaximum(self.maxcolor)
-
         # See if we've connected to a camera with valid height and width
         if (
             self.rowPv is None
@@ -2081,6 +2064,23 @@ class GraphicUserInterface(QMainWindow):
             self.count = self.rowPv.value * self.colPv.value
             if self.isColor:
                 self.count *= 3
+
+        if self.lFlags[index] != "":
+            self.bits = int(self.lFlags[index])
+        else:
+            self.bits_pv = self.connectPv(self.cameraBase + ":BitsPerPixel_RBV")
+            if self.bits_pv is None:
+                self.ui.label_status.setText("IOC timeout in setup")
+                print("IOC timeout in setup (bits per pixel PV)")
+                return
+            self.bits = self.bits_pv.value
+        self.maxcolor = (1 << self.bits) - 1
+        self.ui.horizontalSliderRangeMin.setMaximum(self.maxcolor)
+        self.ui.horizontalSliderRangeMin.setTickInterval((1 << self.bits) / 4)
+        self.ui.horizontalSliderRangeMax.setMaximum(self.maxcolor)
+        self.ui.horizontalSliderRangeMax.setTickInterval((1 << self.bits) / 4)
+        self.ui.spinbox_range_max.setMaximum(self.maxcolor)
+        self.ui.spinbox_range_min.setMaximum(self.maxcolor)
 
         # Try to connect to the camera
         self.camera = self.connectPv(sCameraPv, count=self.count)

--- a/camviewer_ui_impl.py
+++ b/camviewer_ui_impl.py
@@ -1422,9 +1422,19 @@ class GraphicUserInterface(QMainWindow):
             and self.camera is not None
         ):
             try:
-                self.count = self.rowPv.value * self.colPv.value
-                if self.isColor:
-                    self.count *= 3
+                try:
+                    new_count = int(self.rowPv.value) * int(self.colPv.value)
+                except Exception:
+                    # Something went wrong with our row/col PVs
+                    # One of disconnected, bad data, etc.
+                    # Use the previous frame's count for now
+                    # If it's wrong, the frame will get dropped by pycaqtimage
+                    ...
+                else:
+                    # Our PVs are OK, let's make sure we get the right amount of data
+                    if self.isColor:
+                        new_count *= 3
+                    self.count = new_count
                 self.camera.get(count=self.count, timeout=None)
                 pyca.flush_io()
             except Exception:

--- a/camviewer_ui_impl.py
+++ b/camviewer_ui_impl.py
@@ -302,7 +302,6 @@ class GraphicUserInterface(QMainWindow):
         self.launch_edm_pv = None
         self.launch_gui_script = ""
         self.launch_edm_script = ""
-        self.scale = 1
         self.fLensPrevValue = -1
         self.fLensValue = 0
         self.avgState = SINGLE_FRAME
@@ -1343,8 +1342,8 @@ class GraphicUserInterface(QMainWindow):
 
     def onSizeUpdate(self):
         try:
-            newx = self.colPv.value / self.scale
-            newy = self.rowPv.value / self.scale
+            newx = self.colPv.value
+            newy = self.rowPv.value
             if newx != param.x or newy != self.y:
                 self.setImageSize(newx, newy, False)
         except Exception:
@@ -2030,7 +2029,6 @@ class GraphicUserInterface(QMainWindow):
         )
 
         # Try to get the camera size!
-        self.scale = 1
         size0 = self.connectPv(self.cameraBase + ":ArraySize0_RBV")
         size1 = self.connectPv(self.cameraBase + ":ArraySize1_RBV")
         size2 = self.connectPv(self.cameraBase + ":ArraySize2_RBV")
@@ -2122,9 +2120,7 @@ class GraphicUserInterface(QMainWindow):
         self.rowPv.add_monitor_callback(self.sizeCallback)
         self.colPv.add_monitor_callback(self.sizeCallback)
         # Now, before we monitor, update the camera size!
-        self.setImageSize(
-            self.colPv.value / self.scale, self.rowPv.value / self.scale, True
-        )
+        self.setImageSize(self.colPv.value, self.rowPv.value, True)
         self.updateMarkerText(True, True, 0, 15)
         self.notify.monitor(
             pyca.DBE_VALUE, False, 1
@@ -2462,9 +2458,7 @@ class GraphicUserInterface(QMainWindow):
                     self.ui.projectionFrame.setFixedSize(
                         QSize(self.projsize, self.projsize)
                     )
-            self.setImageSize(
-                self.colPv.value / self.scale, self.rowPv.value / self.scale, False
-            )
+            self.setImageSize(self.colPv.value, self.rowPv.value, False)
             if self.cfg is None:
                 self.dumpConfig()
 

--- a/camviewer_ui_impl.py
+++ b/camviewer_ui_impl.py
@@ -2032,23 +2032,29 @@ class GraphicUserInterface(QMainWindow):
         size0 = self.connectPv(self.cameraBase + ":ArraySize0_RBV")
         size1 = self.connectPv(self.cameraBase + ":ArraySize1_RBV")
         size2 = self.connectPv(self.cameraBase + ":ArraySize2_RBV")
-        if None in (size0, size1, size2):
+        if None in (size0, size1):
+            # Note: allow B/W cams to not have a size2 PV
             self.ui.label_status.setText("IOC timeout in setup")
             print("IOC timeout in setup (image size PVs)")
             return
 
-        if size0.value == 3:
+        if size2 is None or size2.value == 0:
+            # Just B/W!
+            self.rowPv = size1
+            self.colPv = size0
+            self.disconnectPv(size2)
+            self.isColor = False
+        elif size0.value == 3:
             # It's a color camera!
             self.rowPv = size2
             self.colPv = size1
             self.disconnectPv(size0)
             self.isColor = True
         else:
-            # Just B/W!
-            self.rowPv = size1
-            self.colPv = size0
-            self.disconnectPv(size2)
-            self.isColor = False
+            # Something else? e.g. 100x100x100
+            self.ui.label_status.setText("Invalid cam dimemsions")
+            print("Invalid cam dimensions in setup (3d or more)")
+            return
 
         # See if we've connected to a camera with valid height and width
         if (

--- a/pycaqtimage/configure.py
+++ b/pycaqtimage/configure.py
@@ -51,6 +51,8 @@ extraFlags = "-std=c++11 -I%s -I%s/QtCore -I%s/QtGui -I%s -DQT_NO_VERSION_TAGGIN
     qt_inc_dir,
     np_inc_dir,
 )
+# If you need debug symbols
+# extraFlags += " -g"
 makefile.extra_cflags = [extraFlags]
 makefile.extra_cxxflags = [extraFlags]
 makefile.extra_lflags = ["-Wl,-R" + target_dir + " -Wl,-R" + qt_lib_dir]


### PR DESCRIPTION
### Main Goal
- Remove .NORD and .NELM references as they are redundant and seem to get dropped by our gateway servers.
- Use the array size information from area detector PVs to set the array counts wherever we were doing this previously

### Changes to `__init__`
This is called at GUI startup.

- remove references to now unused norm, nelm pvs and max counts.

### Changes to `wantImage`
This is called whenever it's time to collect and render a new image.

- Replace nord -> count pipeline with a row * col -> count pipeline (or *3 if color cam)
- Pass count into the PV acquisition in case count has changed (unreported bug, fixed)

### Changes to `connectCamera`
This is called whenever someone selects a new camera to initialize, if the camera looks like its online.

- Move EPICS-sourced-string re-inits to empty string to `self.clear`, which where we moved the `disconnectPv` calls in #34 
- Remove nord, nelm pvs
- Clean up the sizing information initialization
- Fix an issue where the wrong bit count PV was used and clean up the bit count setup
- Remove vestigial self.scale
- General cleanup


And last and maybe most important, I rearranged the initilaization order:

#### Old order
1. Nord/nelm -> count
2. Connect to image PV
3. Get xy, color, bit depth info

#### New order
1. Connect to `x*y*color` -> count
2. Connect to bit depth PV, get bit depth
3. Connect to image PV