### PR TITLE
FIX: if initial selected camera is not ready, wait up to 3s

### DIFF
--- a/camviewer_ui_impl.py
+++ b/camviewer_ui_impl.py
@@ -703,7 +703,15 @@ class GraphicUserInterface(QMainWindow):
             if cameraIndex < 0 or cameraIndex >= len(self.lCameraList):
                 print("Invalid camera index %d" % cameraIndex)
                 cameraIndex = 0
-            self.onCameraSelect(int(cameraIndex))
+            cameraIndex = int(cameraIndex)
+            # Camera select is gated by our camconn list of connected statuses
+            # We could wait on the pv connected status but that might let us through early
+            # Most robust is this simple sleep/wait loop
+            for _ in range(30):
+                if self.camconn[cameraIndex]:
+                    break
+                time.sleep(0.1)
+            self.onCameraSelect(cameraIndex)
         except Exception:
             pass
 


### PR DESCRIPTION
As it says in the title.

I chose not to use the psp wait primitives because they let us through prior to the connection callbacks being run. I then opted for a less sophisticated but more simple wait loop.

I've verified that several live cameras connect successfully and that the GUI waits a little extra before giving up for cameras that are truly disconnected (on startup)