### PR TITLE
FIX: allow camviewer to process color images with large pixels

### DIFF
--- a/pycaqtimage/pycaqtimage.sip
+++ b/pycaqtimage/pycaqtimage.sip
@@ -396,10 +396,10 @@ void _pyDoAvg(ImageBuffer *imageBuffer, T *cadata)
 	_pyCopyToQImage(imageBuffer, 1);
 }
 
-static void _pyColorImagePvCallback(void* cadata, long count, size_t size, void* usr)
+template <class T>
+void _pyDoAvgColor(ImageBuffer *imageBuffer, T *cadata)
 {
-    ImageBuffer*  imageBuffer = reinterpret_cast<ImageBuffer*>(usr);
-    uint8_t*  src    = reinterpret_cast<uint8_t*>(cadata); /* R, G, B! */
+    T*  src    = cadata; /* R, G, B! */
     uint32_t *dst    = imageBuffer->imageData;
     float    *dstF   = imageBuffer->imageDataF;
     int orientation  = imageBuffer->orientation;
@@ -412,13 +412,6 @@ static void _pyColorImagePvCallback(void* cadata, long count, size_t size, void*
     int col_inc      = imageBuffer->srcwidth * colIncMult[orientation] +
                        colIncK[orientation];
     int iNewAverage  = imageBuffer->iNumAveraged + 1;
-
-    UNUSED(size);
-
-    if (count != imageBuffer->size * 3) {
-        // Wrong data size, unsafe to continue
-        return;
-    }
 
     /* If we're using the color image, don't average, just copy and we're done! */
     if (!imageBuffer->useGray) {
@@ -457,6 +450,31 @@ static void _pyColorImagePvCallback(void* cadata, long count, size_t size, void*
 
 	if (iNewAverage == imageBuffer->iAverage)
 	    _pyCopyToQImage(imageBuffer, 1);
+    }
+}
+
+static void _pyColorImagePvCallback(void* cadata, long count, size_t size, void* usr)
+{
+    ImageBuffer*  imageBuffer = reinterpret_cast<ImageBuffer*>(usr);
+
+    if (count != imageBuffer->size * 3) {
+        // Wrong data size, unsafe to continue
+        return;
+    }
+
+    switch (size) {
+        case 4:
+        _pyDoAvgColor(imageBuffer, reinterpret_cast<uint32_t*>(cadata));
+            break;
+        case 2:
+        _pyDoAvgColor(imageBuffer, reinterpret_cast<uint16_t*>(cadata));
+            break;
+        case 1:
+        _pyDoAvgColor(imageBuffer, reinterpret_cast<uint8_t*>(cadata));
+            break;
+        default:
+            fprintf(stderr, "Image pixel size is %d bytes?\n", (int) size);
+        break;
     }
 }
 

--- a/pycaqtimage/pycaqtimage.sip
+++ b/pycaqtimage/pycaqtimage.sip
@@ -458,7 +458,7 @@ static void _pyColorImagePvCallback(void* cadata, long count, size_t size, void*
     ImageBuffer*  imageBuffer = reinterpret_cast<ImageBuffer*>(usr);
 
     if (count != imageBuffer->size * 3) {
-        // Wrong data size, unsafe to continue
+        fprintf(stderr, "Wrong data size %d, expected %d. unsafe to continue\n", count, imageBuffer->size * 3);
         return;
     }
 
@@ -471,7 +471,7 @@ static void _pyColorImagePvCallback(void* cadata, long count, size_t size, void*
         _pyDoAvgColor(imageBuffer, reinterpret_cast<uint8_t*>(cadata));
             break;
         default:
-            fprintf(stderr, "Image pixel size is %d bytes?\n", (int) size);
+            fprintf(stderr, "Image pixel size is %d bytes, must be 1 or 2.\n", (int) size);
         break;
     }
 }
@@ -481,7 +481,7 @@ static void _pyImagePvCallback(void* cadata, long count, size_t size, void* usr)
   ImageBuffer*  imageBuffer = reinterpret_cast<ImageBuffer*>(usr);
 
   if (count != imageBuffer->size) {
-    // Wrong data size, unsafe to continue
+    fprintf(stderr, "Wrong data size %d, expected %d. unsafe to continue\n", count, imageBuffer->size);
     return;
   }
 
@@ -496,7 +496,7 @@ static void _pyImagePvCallback(void* cadata, long count, size_t size, void* usr)
 	_pyDoAvg(imageBuffer, reinterpret_cast<uint8_t*>(cadata));
         break;
     default:
-        fprintf(stderr, "Image pixel size is %d bytes?\n", (int) size);
+        fprintf(stderr, "Image pixel size is %d bytes, must be 1, 2, or 4.\n", (int) size);
 	break;
   }
 }

--- a/pycaqtimage/pycaqtimage.sip
+++ b/pycaqtimage/pycaqtimage.sip
@@ -463,6 +463,7 @@ static void _pyColorImagePvCallback(void* cadata, long count, size_t size, void*
     }
 
     switch (size) {
+        // size 4 will crash the rgb accumulator
         case 2:
         _pyDoAvgColor(imageBuffer, reinterpret_cast<uint16_t*>(cadata));
             break;

--- a/pycaqtimage/pycaqtimage.sip
+++ b/pycaqtimage/pycaqtimage.sip
@@ -458,7 +458,7 @@ static void _pyColorImagePvCallback(void* cadata, long count, size_t size, void*
     ImageBuffer*  imageBuffer = reinterpret_cast<ImageBuffer*>(usr);
 
     if (count != imageBuffer->size * 3) {
-        fprintf(stderr, "Wrong data size %d, expected %d. unsafe to continue\n", count, imageBuffer->size * 3);
+        fprintf(stderr, "Wrong data size %ld, expected %d. unsafe to continue\n", count, imageBuffer->size * 3);
         return;
     }
 
@@ -481,7 +481,7 @@ static void _pyImagePvCallback(void* cadata, long count, size_t size, void* usr)
   ImageBuffer*  imageBuffer = reinterpret_cast<ImageBuffer*>(usr);
 
   if (count != imageBuffer->size) {
-    fprintf(stderr, "Wrong data size %d, expected %d. unsafe to continue\n", count, imageBuffer->size);
+    fprintf(stderr, "Wrong data size %ld, expected %d. unsafe to continue\n", count, imageBuffer->size);
     return;
   }
 

--- a/pycaqtimage/pycaqtimage.sip
+++ b/pycaqtimage/pycaqtimage.sip
@@ -458,7 +458,7 @@ static void _pyColorImagePvCallback(void* cadata, long count, size_t size, void*
     ImageBuffer*  imageBuffer = reinterpret_cast<ImageBuffer*>(usr);
 
     if (count != imageBuffer->size * 3) {
-        fprintf(stderr, "Wrong data size %ld, expected %d. unsafe to continue\n", count, imageBuffer->size * 3);
+        fprintf(stderr, "Wrong data size %ld, expected %d. Unsafe to continue\n", count, imageBuffer->size * 3);
         return;
     }
 
@@ -481,7 +481,7 @@ static void _pyImagePvCallback(void* cadata, long count, size_t size, void* usr)
   ImageBuffer*  imageBuffer = reinterpret_cast<ImageBuffer*>(usr);
 
   if (count != imageBuffer->size) {
-    fprintf(stderr, "Wrong data size %ld, expected %d. unsafe to continue\n", count, imageBuffer->size);
+    fprintf(stderr, "Wrong data size %ld, expected %d. Unsafe to continue\n", count, imageBuffer->size);
     return;
   }
 

--- a/pycaqtimage/pycaqtimage.sip
+++ b/pycaqtimage/pycaqtimage.sip
@@ -463,9 +463,6 @@ static void _pyColorImagePvCallback(void* cadata, long count, size_t size, void*
     }
 
     switch (size) {
-        case 4:
-        _pyDoAvgColor(imageBuffer, reinterpret_cast<uint32_t*>(cadata));
-            break;
         case 2:
         _pyDoAvgColor(imageBuffer, reinterpret_cast<uint16_t*>(cadata));
             break;


### PR DESCRIPTION
Ref https://jira.slac.stanford.edu/browse/ECS-8777

camViewer was failing to render images from cameras using vimbaCam
After some debug I noticed that the pixel values in the resulting image were strange, with zero values in every other slot, e.g.:
rgb = (5, 0, 5)
rgb = (0, 5, 0)
rgb = (6, 0, 4)

I tracked this down to the image data type being SHORT (2 bytes per element) instead of CHAR (1 byte per element)

I duplicated the logic used to handle these higher-sized arrays for mono cameras into the color cams section

Before:

<img width="934" height="807" alt="vimba_color_broken" src="https://github.com/user-attachments/assets/c295b971-35e9-46fd-b75c-3fb9d52034bf" />

After:

<img width="934" height="807" alt="vimba_color_working" src="https://github.com/user-attachments/assets/91a84284-0a81-491d-9bc2-7bbb7e86b303" />


Possibly we could do some more testing but I wanted to put this up before stopping for the day
