### PR TITLE
MNT: include c-reviewers for the sip plugin and makefile

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,5 +10,11 @@
 *.pyx @pcdshub/ui-sme @pcdshub/python-reviewers
 *.pyd @pcdshub/ui-sme @pcdshub/python-reviewers
 
+## C++ sip plugin
+pycaqtimage/** @pcdshub/ui-sme @pcdshub/c-reviewers
+
+## Makefile
+Makefile @pcdshub/ui-sme @pcdshub/python-reviewers @pcdshub/c-reviewers
+
 # github folder holds administrative files
 .github/** @pcdshub/software-admin


### PR DESCRIPTION
So it's not just Robert and I getting pinged when something gets updated here

I decided to use the underutilized c-reviewers group
I thought the Makefile needed attention from both c-reviewers and from python-reviewers because it relates to both frameworks