### PR TITLE
FIX: disable all sub-scrolling behavior inside the right hand scroll area

### DIFF
--- a/cam_types.py
+++ b/cam_types.py
@@ -40,6 +40,7 @@ class CamTypeScreenGenerator(QObject):
     final_name = pyqtSignal(str)
     manuf_ready = pyqtSignal()
     model_ready = pyqtSignal()
+    form_finalized = pyqtSignal()
 
     def __init__(self, base_pv: str, form: QFormLayout, parent: QObject | None = None):
         super().__init__(parent=parent)
@@ -56,6 +57,7 @@ class CamTypeScreenGenerator(QObject):
         ]
         self.finish_ran = False
         self.finish_lock = Lock()
+        self.finalized = False
 
         # Put in the form elements that always should be there
         self.acq_label = QLabel(STOP_TEXT)
@@ -178,6 +180,8 @@ class CamTypeScreenGenerator(QObject):
             )
         self.pvs_to_clean_up.extend(finisher_pvs)
         self.sigs_to_clean_up.extend(finisher_sigs)
+        self.finalized = True
+        self.form_finalized.emit()
 
     def new_acq_value(self, error: Exception | None) -> None:
         """

--- a/camviewer_ui_impl.py
+++ b/camviewer_ui_impl.py
@@ -216,7 +216,6 @@ class NoScrollWheelFilter(QObject):
         return False
 
 
-
 SINGLE_FRAME = 0
 LOCAL_AVERAGE = 2
 

--- a/camviewer_ui_impl.py
+++ b/camviewer_ui_impl.py
@@ -48,6 +48,7 @@ from PyQt5.QtWidgets import (
     QMessageBox,
     QSizePolicy,
     QSpacerItem,
+    QWidget,
 )
 
 import param
@@ -201,6 +202,19 @@ class ScrollSizeFilter(QObject):
         elif event.type() == QEvent.Hide:
             self.set_no_scroll_size()
         return False
+
+
+class NoScrollWheelFilter(QObject):
+    """
+    A filter that prevents the scroll wheel from being used to interact with widgets.
+    """
+
+    def eventFilter(self, _, event) -> bool:
+        if event.type() == QEvent.Wheel:
+            # True stops all other event processing
+            return True
+        return False
+
 
 
 SINGLE_FRAME = 0
@@ -716,6 +730,9 @@ class GraphicUserInterface(QMainWindow):
         self.ui.rightPanelWidget.setFixedWidth(width)
 
         self.efilter = FilterObject(self.app, self)
+        self.no_scroll_filter = NoScrollWheelFilter(parent=self)
+        for child_widget in self.ui.rightPanelWidget.findChildren(QWidget):
+            child_widget.installEventFilter(self.no_scroll_filter)
 
         # Timer with 0 delay = end of event queue
         # i.e. immediately after all the queued initial rendering

--- a/camviewer_ui_impl.py
+++ b/camviewer_ui_impl.py
@@ -210,10 +210,16 @@ class NoScrollWheelFilter(QObject):
     """
 
     def eventFilter(self, _, event) -> bool:
+        """Override default eventFilter to ignore scroll wheel."""
         if event.type() == QEvent.Wheel:
             # True stops all other event processing
             return True
         return False
+
+    def install_on_children(self, widget: QWidget):
+        """Helper for disabling scrollwheel on all widgets in a container."""
+        for child_widget in widget.findChildren(QWidget):
+            child_widget.installEventFilter(self)
 
 
 SINGLE_FRAME = 0
@@ -730,8 +736,9 @@ class GraphicUserInterface(QMainWindow):
 
         self.efilter = FilterObject(self.app, self)
         self.no_scroll_filter = NoScrollWheelFilter(parent=self)
-        for child_widget in self.ui.rightPanelWidget.findChildren(QWidget):
-            child_widget.installEventFilter(self.no_scroll_filter)
+        self.no_scroll_filter.install_on_children(self.ui.rightPanelWidget)
+        # specificdialog is sometimes in the scroll area, sometimes not
+        self.no_scroll_filter.install_on_children(self.specificdialog)
 
         # Timer with 0 delay = end of event queue
         # i.e. immediately after all the queued initial rendering
@@ -2183,11 +2190,17 @@ class GraphicUserInterface(QMainWindow):
             form = self.ui.groupBoxControls.layout()
         self.cam_type_screen_generator = CamTypeScreenGenerator(self.ctrlBase, form)
         self.cam_type_screen_generator.final_name.connect(self.new_model_name)
+        self.cam_type_screen_generator.form_finalized.connect(self.disable_scroll_in_cam_controls)
         if self.cam_type_screen_generator.full_name:
             self.new_model_name(self.cam_type_screen_generator.full_name)
+        if self.cam_type_screen_generator.finalized:
+            self.disable_scroll_in_cam_controls()
 
     def new_model_name(self, name: str):
         self.ui.groupBoxControls.setTitle(f"{name} Controls")
+
+    def disable_scroll_in_cam_controls(self):
+        self.no_scroll_filter.install_on_children(self.ui.groupBoxControls)
 
     def normalize_selectors(self):
         """


### PR DESCRIPTION
It's common for scientists to scroll down the right hand size of the GUI which currently can change settings, orientations, etc. and generally be a menace.

This applies a no-scrolling-allowed filter to every widget inside the right-hand scroll area widget. The scroll widget can still be scrolled with the scroll wheel, but the contents will simply be put in focus like any other mouse event instead of moved/changed via scroll.

I applied this broadly to QWidgets instead of selecting specific types or names of widgets so a future maintainer does not need to specify new widget types when more are added.

Ref

- https://jira.slac.stanford.edu/browse/ECS-7935
- https://jira.slac.stanford.edu/browse/ECS-9081
